### PR TITLE
Add richer NIR fixtures to roundtrip testing

### DIFF
--- a/v2m/core/formats/tests/roundtrip.rs
+++ b/v2m/core/formats/tests/roundtrip.rs
@@ -24,14 +24,24 @@ fn constraints_roundtrip_snapshot() {
 
 #[test]
 fn nir_roundtrip_snapshot() {
-    let path = examples_dir().join("nir/minimal.json");
-    let doc = formats::nir::from_reader(File::open(&path).expect("open nir")).expect("load nir");
-    let mut buf = Vec::new();
-    formats::nir::to_writer(&doc, &mut buf).expect("write nir");
-    let doc2 = formats::nir::from_reader(buf.as_slice()).expect("reload nir");
-    assert_eq!(doc, doc2);
-    let value: Value = serde_json::from_slice(&buf).expect("roundtrip value");
-    assert_json_snapshot!("nir_roundtrip", value);
+    let fixtures = ["minimal.json", "full_adder.json", "counter.json"];
+    let base_dir = examples_dir().join("nir");
+
+    for fixture in fixtures {
+        let path = base_dir.join(fixture);
+        let doc =
+            formats::nir::from_reader(File::open(&path).expect("open nir")).expect("load nir");
+        let mut buf = Vec::new();
+        formats::nir::to_writer(&doc, &mut buf).expect("write nir");
+        let doc2 = formats::nir::from_reader(buf.as_slice()).expect("reload nir");
+        assert_eq!(doc, doc2);
+        let value: Value = serde_json::from_slice(&buf).expect("roundtrip value");
+        let snapshot_name = format!(
+            "nir_roundtrip__{}",
+            fixture.strip_suffix(".json").unwrap_or(fixture)
+        );
+        assert_json_snapshot!(snapshot_name, value);
+    }
 }
 
 #[test]

--- a/v2m/core/formats/tests/snapshots/roundtrip__nir_roundtrip__counter.snap
+++ b/v2m/core/formats/tests/snapshots/roundtrip__nir_roundtrip__counter.snap
@@ -1,0 +1,168 @@
+---
+source: core/formats/tests/roundtrip.rs
+expression: value
+---
+{
+  "attrs": {
+    "description": "4-bit counter with enable and synchronous reset"
+  },
+  "design": "counter",
+  "modules": {
+    "Counter": {
+      "nets": {
+        "clk": {
+          "bits": 1
+        },
+        "en": {
+          "bits": 1
+        },
+        "enabled_next": {
+          "bits": 4
+        },
+        "incremented": {
+          "bits": 4
+        },
+        "next": {
+          "bits": 4
+        },
+        "reset": {
+          "bits": 1
+        },
+        "value": {
+          "bits": 4
+        }
+      },
+      "nodes": {
+        "add_inc": {
+          "op": "ADD",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "value"
+            },
+            "B": {
+              "const": "0001",
+              "width": 4
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "incremented"
+            }
+          },
+          "uid": "add_inc",
+          "width": 4
+        },
+        "mux_enable": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "value"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "incremented"
+            },
+            "S": {
+              "concat": [
+                {
+                  "lsb": 0,
+                  "msb": 0,
+                  "net": "en"
+                }
+              ]
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "enabled_next"
+            }
+          },
+          "uid": "mux_enable",
+          "width": 4
+        },
+        "mux_reset": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "enabled_next"
+            },
+            "B": {
+              "const": "0000",
+              "width": 4
+            },
+            "S": {
+              "concat": [
+                {
+                  "lsb": 0,
+                  "msb": 0,
+                  "net": "reset"
+                }
+              ]
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "next"
+            }
+          },
+          "uid": "mux_reset",
+          "width": 4
+        },
+        "state_reg": {
+          "op": "DFF",
+          "pin_map": {
+            "CLK": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "clk"
+            },
+            "D": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "next"
+            },
+            "Q": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "value"
+            },
+            "RST": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "reset"
+            }
+          },
+          "uid": "state_reg",
+          "width": 4
+        }
+      },
+      "ports": {
+        "clk": {
+          "bits": 1,
+          "dir": "input"
+        },
+        "en": {
+          "bits": 1,
+          "dir": "input"
+        },
+        "reset": {
+          "bits": 1,
+          "dir": "input"
+        },
+        "value": {
+          "bits": 4,
+          "dir": "output"
+        }
+      }
+    }
+  },
+  "top": "Counter",
+  "v": "nir-1.1"
+}

--- a/v2m/core/formats/tests/snapshots/roundtrip__nir_roundtrip__full_adder.snap
+++ b/v2m/core/formats/tests/snapshots/roundtrip__nir_roundtrip__full_adder.snap
@@ -1,0 +1,173 @@
+---
+source: core/formats/tests/roundtrip.rs
+expression: value
+---
+{
+  "design": "full_adder",
+  "modules": {
+    "FullAdder": {
+      "nets": {
+        "a": {
+          "bits": 1
+        },
+        "b": {
+          "bits": 1
+        },
+        "carry_ab": {
+          "bits": 1
+        },
+        "carry_cin": {
+          "bits": 1
+        },
+        "cin": {
+          "bits": 1
+        },
+        "cout": {
+          "bits": 1
+        },
+        "sum": {
+          "bits": 1
+        },
+        "sum_ab": {
+          "bits": 1
+        }
+      },
+      "nodes": {
+        "and_ab": {
+          "op": "AND",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "a"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "b"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "carry_ab"
+            }
+          },
+          "uid": "and_ab",
+          "width": 1
+        },
+        "and_cin": {
+          "op": "AND",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "sum_ab"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "cin"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "carry_cin"
+            }
+          },
+          "uid": "and_cin",
+          "width": 1
+        },
+        "or_carry": {
+          "op": "OR",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "carry_ab"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "carry_cin"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "cout"
+            }
+          },
+          "uid": "or_carry",
+          "width": 1
+        },
+        "xor_ab": {
+          "op": "XOR",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "a"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "b"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "sum_ab"
+            }
+          },
+          "uid": "xor_ab",
+          "width": 1
+        },
+        "xor_sum": {
+          "op": "XOR",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "sum_ab"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "cin"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "sum"
+            }
+          },
+          "uid": "xor_sum",
+          "width": 1
+        }
+      },
+      "ports": {
+        "a": {
+          "bits": 1,
+          "dir": "input"
+        },
+        "b": {
+          "bits": 1,
+          "dir": "input"
+        },
+        "cin": {
+          "bits": 1,
+          "dir": "input"
+        },
+        "cout": {
+          "bits": 1,
+          "dir": "output"
+        },
+        "sum": {
+          "bits": 1,
+          "dir": "output"
+        }
+      }
+    }
+  },
+  "top": "FullAdder",
+  "v": "nir-1.1"
+}

--- a/v2m/core/formats/tests/snapshots/roundtrip__nir_roundtrip__minimal.snap
+++ b/v2m/core/formats/tests/snapshots/roundtrip__nir_roundtrip__minimal.snap
@@ -1,6 +1,5 @@
 ---
 source: core/formats/tests/roundtrip.rs
-assertion_line: 35
 expression: value
 ---
 {

--- a/v2m/examples/nir/counter.json
+++ b/v2m/examples/nir/counter.json
@@ -1,0 +1,72 @@
+{
+  "v": "nir-1.1",
+  "design": "counter",
+  "top": "Counter",
+  "attrs": {
+    "description": "4-bit counter with enable and synchronous reset"
+  },
+  "modules": {
+    "Counter": {
+      "ports": {
+        "clk": { "dir": "input", "bits": 1 },
+        "reset": { "dir": "input", "bits": 1 },
+        "en": { "dir": "input", "bits": 1 },
+        "value": { "dir": "output", "bits": 4 }
+      },
+      "nets": {
+        "clk": { "bits": 1 },
+        "reset": { "bits": 1 },
+        "en": { "bits": 1 },
+        "value": { "bits": 4 },
+        "incremented": { "bits": 4 },
+        "enabled_next": { "bits": 4 },
+        "next": { "bits": 4 }
+      },
+      "nodes": {
+        "add_inc": {
+          "uid": "add_inc",
+          "op": "ADD",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "value", "lsb": 0, "msb": 3 },
+            "B": { "const": "0001", "width": 4 },
+            "Y": { "net": "incremented", "lsb": 0, "msb": 3 }
+          }
+        },
+        "mux_enable": {
+          "uid": "mux_enable",
+          "op": "MUX",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "value", "lsb": 0, "msb": 3 },
+            "B": { "net": "incremented", "lsb": 0, "msb": 3 },
+            "S": { "concat": [ { "net": "en", "lsb": 0, "msb": 0 } ] },
+            "Y": { "net": "enabled_next", "lsb": 0, "msb": 3 }
+          }
+        },
+        "mux_reset": {
+          "uid": "mux_reset",
+          "op": "MUX",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "enabled_next", "lsb": 0, "msb": 3 },
+            "B": { "const": "0000", "width": 4 },
+            "S": { "concat": [ { "net": "reset", "lsb": 0, "msb": 0 } ] },
+            "Y": { "net": "next", "lsb": 0, "msb": 3 }
+          }
+        },
+        "state_reg": {
+          "uid": "state_reg",
+          "op": "DFF",
+          "width": 4,
+          "pin_map": {
+            "D": { "net": "next", "lsb": 0, "msb": 3 },
+            "Q": { "net": "value", "lsb": 0, "msb": 3 },
+            "CLK": { "net": "clk", "lsb": 0, "msb": 0 },
+            "RST": { "net": "reset", "lsb": 0, "msb": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/v2m/examples/nir/full_adder.json
+++ b/v2m/examples/nir/full_adder.json
@@ -1,0 +1,78 @@
+{
+  "v": "nir-1.1",
+  "design": "full_adder",
+  "top": "FullAdder",
+  "modules": {
+    "FullAdder": {
+      "ports": {
+        "a": { "dir": "input", "bits": 1 },
+        "b": { "dir": "input", "bits": 1 },
+        "cin": { "dir": "input", "bits": 1 },
+        "sum": { "dir": "output", "bits": 1 },
+        "cout": { "dir": "output", "bits": 1 }
+      },
+      "nets": {
+        "a": { "bits": 1 },
+        "b": { "bits": 1 },
+        "cin": { "bits": 1 },
+        "sum": { "bits": 1 },
+        "cout": { "bits": 1 },
+        "sum_ab": { "bits": 1 },
+        "carry_ab": { "bits": 1 },
+        "carry_cin": { "bits": 1 }
+      },
+      "nodes": {
+        "xor_ab": {
+          "uid": "xor_ab",
+          "op": "XOR",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 0 },
+            "B": { "net": "b", "lsb": 0, "msb": 0 },
+            "Y": { "net": "sum_ab", "lsb": 0, "msb": 0 }
+          }
+        },
+        "xor_sum": {
+          "uid": "xor_sum",
+          "op": "XOR",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "sum_ab", "lsb": 0, "msb": 0 },
+            "B": { "net": "cin", "lsb": 0, "msb": 0 },
+            "Y": { "net": "sum", "lsb": 0, "msb": 0 }
+          }
+        },
+        "and_ab": {
+          "uid": "and_ab",
+          "op": "AND",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 0 },
+            "B": { "net": "b", "lsb": 0, "msb": 0 },
+            "Y": { "net": "carry_ab", "lsb": 0, "msb": 0 }
+          }
+        },
+        "and_cin": {
+          "uid": "and_cin",
+          "op": "AND",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "sum_ab", "lsb": 0, "msb": 0 },
+            "B": { "net": "cin", "lsb": 0, "msb": 0 },
+            "Y": { "net": "carry_cin", "lsb": 0, "msb": 0 }
+          }
+        },
+        "or_carry": {
+          "uid": "or_carry",
+          "op": "OR",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "carry_ab", "lsb": 0, "msb": 0 },
+            "B": { "net": "carry_cin", "lsb": 0, "msb": 0 },
+            "Y": { "net": "cout", "lsb": 0, "msb": 0 }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add full_adder and counter NIR example fixtures for broader coverage
- update the NIR roundtrip snapshot test to iterate over the fixtures and create per-fixture snapshots
- record refreshed Insta snapshots for each NIR example

## Testing
- cargo test -p v2m-formats

------
https://chatgpt.com/codex/tasks/task_e_68c9aaaae6708323874b93ac5c3324c1