### PR TITLE
Add NIR normalization snapshots and harness

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -794,6 +794,8 @@ dependencies = [
 name = "v2m-nir"
 version = "0.1.0"
 dependencies = [
+ "insta",
+ "serde",
  "serde_json",
  "thiserror",
  "v2m-formats",

--- a/v2m/core/nir/Cargo.toml
+++ b/v2m/core/nir/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT"
 v2m-formats = { path = "../formats" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 v2m-formats = { path = "../formats" }
+insta = { workspace = true }

--- a/v2m/core/nir/src/lib.rs
+++ b/v2m/core/nir/src/lib.rs
@@ -3,9 +3,14 @@ use std::collections::{BTreeSet, BinaryHeap, HashMap};
 use std::fmt;
 
 mod lint;
+mod normalize;
 mod strash;
 
 pub use lint::{lint_module, lint_nir, Driver, LintError};
+pub use normalize::{
+    normalize_module, normalize_nir, NormalizeError, NormalizedLiteral, NormalizedModule,
+    NormalizedNir, NormalizedNode, NormalizedNodeKind, StateBitSnapshot, StateSnapshot,
+};
 pub use strash::{Literal, ParamMap, StrashKind, StrashNode, StrashNodeId, StructuralHasher};
 
 use v2m_formats::nir::{Module, NodeOp};

--- a/v2m/core/nir/tests/nir_golden.rs
+++ b/v2m/core/nir/tests/nir_golden.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+use v2m_formats::load_nir;
+use v2m_nir::normalize_nir;
+
+fn data_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/golden/nir")
+}
+
+fn load_normalized(name: &str) -> v2m_nir::NormalizedNir {
+    let path = data_dir().join(format!("{name}.nir.json"));
+    let nir = load_nir(&path).expect("load nir design");
+    normalize_nir(&nir).expect("normalize design")
+}
+
+fn assert_snapshot(name: &str) {
+    let mut settings = insta::Settings::new();
+    settings.set_snapshot_path(data_dir());
+    settings.set_snapshot_suffix("snap.json");
+    settings.set_omit_expression(true);
+    settings.set_prepend_module_to_snapshot(false);
+    let _guard = settings.bind_to_scope();
+
+    let design = load_normalized(name);
+    insta::assert_json_snapshot!(name, design);
+}
+
+#[test]
+fn golden_fa1() {
+    assert_snapshot("fa1");
+}
+
+#[test]
+fn golden_alu4() {
+    assert_snapshot("alu4");
+}
+
+#[test]
+fn golden_reg1x8() {
+    assert_snapshot("reg1x8");
+}

--- a/v2m/tests/golden/nir/alu4.nir.json
+++ b/v2m/tests/golden/nir/alu4.nir.json
@@ -1,0 +1,102 @@
+{
+  "v": "nir-1.1",
+  "design": "alu4",
+  "top": "alu4",
+  "modules": {
+    "alu4": {
+      "ports": {
+        "a": { "dir": "input", "bits": 4 },
+        "b": { "dir": "input", "bits": 4 },
+        "op": { "dir": "input", "bits": 2 },
+        "y": { "dir": "output", "bits": 4 }
+      },
+      "nets": {
+        "a": { "bits": 4 },
+        "b": { "bits": 4 },
+        "op": { "bits": 2 },
+        "y": { "bits": 4 },
+        "sum": { "bits": 4 },
+        "and_ab": { "bits": 4 },
+        "or_ab": { "bits": 4 },
+        "xor_ab": { "bits": 4 },
+        "lo_sel": { "bits": 4 },
+        "hi_sel": { "bits": 4 }
+      },
+      "nodes": {
+        "add_sum": {
+          "uid": "add_sum",
+          "op": "ADD",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 3 },
+            "B": { "net": "b", "lsb": 0, "msb": 3 },
+            "Y": { "net": "sum", "lsb": 0, "msb": 3 }
+          }
+        },
+        "and_node": {
+          "uid": "and_node",
+          "op": "AND",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 3 },
+            "B": { "net": "b", "lsb": 0, "msb": 3 },
+            "Y": { "net": "and_ab", "lsb": 0, "msb": 3 }
+          }
+        },
+        "or_node": {
+          "uid": "or_node",
+          "op": "OR",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 3 },
+            "B": { "net": "b", "lsb": 0, "msb": 3 },
+            "Y": { "net": "or_ab", "lsb": 0, "msb": 3 }
+          }
+        },
+        "xor_node": {
+          "uid": "xor_node",
+          "op": "XOR",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 3 },
+            "B": { "net": "b", "lsb": 0, "msb": 3 },
+            "Y": { "net": "xor_ab", "lsb": 0, "msb": 3 }
+          }
+        },
+        "mux_lo": {
+          "uid": "mux_lo",
+          "op": "MUX",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "sum", "lsb": 0, "msb": 3 },
+            "B": { "net": "and_ab", "lsb": 0, "msb": 3 },
+            "S": { "concat": [ { "net": "op", "lsb": 0, "msb": 0 } ] },
+            "Y": { "net": "lo_sel", "lsb": 0, "msb": 3 }
+          }
+        },
+        "mux_hi": {
+          "uid": "mux_hi",
+          "op": "MUX",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "or_ab", "lsb": 0, "msb": 3 },
+            "B": { "net": "xor_ab", "lsb": 0, "msb": 3 },
+            "S": { "concat": [ { "net": "op", "lsb": 0, "msb": 0 } ] },
+            "Y": { "net": "hi_sel", "lsb": 0, "msb": 3 }
+          }
+        },
+        "mux_final": {
+          "uid": "mux_final",
+          "op": "MUX",
+          "width": 4,
+          "pin_map": {
+            "A": { "net": "lo_sel", "lsb": 0, "msb": 3 },
+            "B": { "net": "hi_sel", "lsb": 0, "msb": 3 },
+            "S": { "concat": [ { "net": "op", "lsb": 1, "msb": 1 } ] },
+            "Y": { "net": "y", "lsb": 0, "msb": 3 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/v2m/tests/golden/nir/alu4@snap.json.snap
+++ b/v2m/tests/golden/nir/alu4@snap.json.snap
@@ -1,0 +1,1087 @@
+---
+source: core/nir/tests/nir_golden.rs
+assertion_line: 25
+---
+{
+  "design": "alu4",
+  "top": "alu4",
+  "modules": {
+    "alu4": {
+      "inputs": {
+        "a": [
+          {
+            "node": 0
+          },
+          {
+            "node": 1
+          },
+          {
+            "node": 2
+          },
+          {
+            "node": 3
+          }
+        ],
+        "b": [
+          {
+            "node": 4
+          },
+          {
+            "node": 5
+          },
+          {
+            "node": 6
+          },
+          {
+            "node": 7
+          }
+        ],
+        "op": [
+          {
+            "node": 8
+          },
+          {
+            "node": 9
+          }
+        ]
+      },
+      "outputs": {
+        "y": [
+          {
+            "node": 59
+          },
+          {
+            "node": 62
+          },
+          {
+            "node": 65
+          },
+          {
+            "node": 68
+          }
+        ]
+      },
+      "states": [],
+      "nodes": [
+        {
+          "width": 1,
+          "id": 0,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 1,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 2,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 3,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 4,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 5,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 6,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 7,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 8,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 9,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 10,
+          "kind": {
+            "kind": "const",
+            "bits": "0"
+          }
+        },
+        {
+          "width": 1,
+          "id": 11,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 0
+              },
+              {
+                "node": 4
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 12,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 0
+              },
+              {
+                "node": 4
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 13,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 10
+              },
+              {
+                "node": 12
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 14,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 1
+              },
+              {
+                "node": 5
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 15,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 13
+              },
+              {
+                "node": 14
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 16,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 1
+              },
+              {
+                "node": 5
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 17,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 13
+              },
+              {
+                "node": 14
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 18,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 16
+              },
+              {
+                "node": 17
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 19,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 2
+              },
+              {
+                "node": 6
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 20,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 18
+              },
+              {
+                "node": 19
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 21,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 2
+              },
+              {
+                "node": 6
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 22,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 18
+              },
+              {
+                "node": 19
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 23,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 21
+              },
+              {
+                "node": 22
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 24,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 3
+              },
+              {
+                "node": 7
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 25,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 23
+              },
+              {
+                "node": 24
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 26,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 3
+              },
+              {
+                "node": 7
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 27,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 23
+              },
+              {
+                "node": 24
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 28,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 26
+              },
+              {
+                "node": 27
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 29,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 11
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 30,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 12
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 31,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 29
+              },
+              {
+                "node": 30
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 32,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 15
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 33,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 16
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 34,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 32
+              },
+              {
+                "node": 33
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 35,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 20
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 36,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 21
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 37,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 35
+              },
+              {
+                "node": 36
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 38,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 25
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 39,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 26
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 40,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 38
+              },
+              {
+                "node": 39
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 41,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 0
+              },
+              {
+                "node": 4
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 42,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 1
+              },
+              {
+                "node": 5
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 43,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 2
+              },
+              {
+                "node": 6
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 44,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 3
+              },
+              {
+                "node": 7
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 45,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 41
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 46,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 11
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 47,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 45
+              },
+              {
+                "node": 46
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 48,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 42
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 49,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 14
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 50,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 48
+              },
+              {
+                "node": 49
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 51,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 43
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 52,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 19
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 53,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 51
+              },
+              {
+                "node": 52
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 54,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8,
+                "inverted": true
+              },
+              {
+                "node": 44
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 55,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 24
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 56,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 54
+              },
+              {
+                "node": 55
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 57,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 31
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 58,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9
+              },
+              {
+                "node": 47
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 59,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 57
+              },
+              {
+                "node": 58
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 60,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 34
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 61,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9
+              },
+              {
+                "node": 50
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 62,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 60
+              },
+              {
+                "node": 61
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 63,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 37
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 64,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9
+              },
+              {
+                "node": 53
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 65,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 63
+              },
+              {
+                "node": 64
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 66,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 40
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 67,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9
+              },
+              {
+                "node": 56
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 68,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 66
+              },
+              {
+                "node": 67
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/v2m/tests/golden/nir/fa1.nir.json
+++ b/v2m/tests/golden/nir/fa1.nir.json
@@ -1,0 +1,78 @@
+{
+  "v": "nir-1.1",
+  "design": "fa1",
+  "top": "fa1",
+  "modules": {
+    "fa1": {
+      "ports": {
+        "a": { "dir": "input", "bits": 1 },
+        "b": { "dir": "input", "bits": 1 },
+        "cin": { "dir": "input", "bits": 1 },
+        "sum": { "dir": "output", "bits": 1 },
+        "cout": { "dir": "output", "bits": 1 }
+      },
+      "nets": {
+        "a": { "bits": 1 },
+        "b": { "bits": 1 },
+        "cin": { "bits": 1 },
+        "sum": { "bits": 1 },
+        "cout": { "bits": 1 },
+        "sum_ab": { "bits": 1 },
+        "carry_ab": { "bits": 1 },
+        "carry_cin": { "bits": 1 }
+      },
+      "nodes": {
+        "xor_ab": {
+          "uid": "xor_ab",
+          "op": "XOR",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 0 },
+            "B": { "net": "b", "lsb": 0, "msb": 0 },
+            "Y": { "net": "sum_ab", "lsb": 0, "msb": 0 }
+          }
+        },
+        "xor_sum": {
+          "uid": "xor_sum",
+          "op": "XOR",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "sum_ab", "lsb": 0, "msb": 0 },
+            "B": { "net": "cin", "lsb": 0, "msb": 0 },
+            "Y": { "net": "sum", "lsb": 0, "msb": 0 }
+          }
+        },
+        "and_ab": {
+          "uid": "and_ab",
+          "op": "AND",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "a", "lsb": 0, "msb": 0 },
+            "B": { "net": "b", "lsb": 0, "msb": 0 },
+            "Y": { "net": "carry_ab", "lsb": 0, "msb": 0 }
+          }
+        },
+        "and_cin": {
+          "uid": "and_cin",
+          "op": "AND",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "sum_ab", "lsb": 0, "msb": 0 },
+            "B": { "net": "cin", "lsb": 0, "msb": 0 },
+            "Y": { "net": "carry_cin", "lsb": 0, "msb": 0 }
+          }
+        },
+        "or_carry": {
+          "uid": "or_carry",
+          "op": "OR",
+          "width": 1,
+          "pin_map": {
+            "A": { "net": "carry_ab", "lsb": 0, "msb": 0 },
+            "B": { "net": "carry_cin", "lsb": 0, "msb": 0 },
+            "Y": { "net": "cout", "lsb": 0, "msb": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/v2m/tests/golden/nir/fa1@snap.json.snap
+++ b/v2m/tests/golden/nir/fa1@snap.json.snap
@@ -1,0 +1,145 @@
+---
+source: core/nir/tests/nir_golden.rs
+assertion_line: 25
+---
+{
+  "design": "fa1",
+  "top": "fa1",
+  "modules": {
+    "fa1": {
+      "inputs": {
+        "a": [
+          {
+            "node": 0
+          }
+        ],
+        "b": [
+          {
+            "node": 1
+          }
+        ],
+        "cin": [
+          {
+            "node": 2
+          }
+        ]
+      },
+      "outputs": {
+        "cout": [
+          {
+            "node": 6
+          }
+        ],
+        "sum": [
+          {
+            "node": 7
+          }
+        ]
+      },
+      "states": [],
+      "nodes": [
+        {
+          "width": 1,
+          "id": 0,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 1,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 2,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 3,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 0
+              },
+              {
+                "node": 1
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 4,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 0
+              },
+              {
+                "node": 1
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 5,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 2
+              },
+              {
+                "node": 4
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 6,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 3
+              },
+              {
+                "node": 5
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 7,
+          "kind": {
+            "kind": "op",
+            "op": "XOR",
+            "inputs": [
+              {
+                "node": 2
+              },
+              {
+                "node": 4
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/v2m/tests/golden/nir/reg1x8.nir.json
+++ b/v2m/tests/golden/nir/reg1x8.nir.json
@@ -1,0 +1,45 @@
+{
+  "v": "nir-1.1",
+  "design": "reg1x8",
+  "top": "reg1x8",
+  "modules": {
+    "reg1x8": {
+      "ports": {
+        "clk": { "dir": "input", "bits": 1 },
+        "en": { "dir": "input", "bits": 1 },
+        "d": { "dir": "input", "bits": 8 },
+        "q": { "dir": "output", "bits": 8 }
+      },
+      "nets": {
+        "clk": { "bits": 1 },
+        "en": { "bits": 1 },
+        "d": { "bits": 8 },
+        "q": { "bits": 8 },
+        "next": { "bits": 8 }
+      },
+      "nodes": {
+        "mux_en": {
+          "uid": "mux_en",
+          "op": "MUX",
+          "width": 8,
+          "pin_map": {
+            "A": { "net": "q", "lsb": 0, "msb": 7 },
+            "B": { "net": "d", "lsb": 0, "msb": 7 },
+            "S": { "concat": [ { "net": "en", "lsb": 0, "msb": 0 } ] },
+            "Y": { "net": "next", "lsb": 0, "msb": 7 }
+          }
+        },
+        "state_reg": {
+          "uid": "state_reg",
+          "op": "DFF",
+          "width": 8,
+          "pin_map": {
+            "D": { "net": "next", "lsb": 0, "msb": 7 },
+            "Q": { "net": "q", "lsb": 0, "msb": 7 },
+            "CLK": { "net": "clk", "lsb": 0, "msb": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/v2m/tests/golden/nir/reg1x8@snap.json.snap
+++ b/v2m/tests/golden/nir/reg1x8@snap.json.snap
@@ -1,0 +1,685 @@
+---
+source: core/nir/tests/nir_golden.rs
+assertion_line: 25
+---
+{
+  "design": "reg1x8",
+  "top": "reg1x8",
+  "modules": {
+    "reg1x8": {
+      "inputs": {
+        "clk": [
+          {
+            "node": 0
+          }
+        ],
+        "d": [
+          {
+            "node": 1
+          },
+          {
+            "node": 2
+          },
+          {
+            "node": 3
+          },
+          {
+            "node": 4
+          },
+          {
+            "node": 5
+          },
+          {
+            "node": 6
+          },
+          {
+            "node": 7
+          },
+          {
+            "node": 8
+          }
+        ],
+        "en": [
+          {
+            "node": 9
+          }
+        ]
+      },
+      "outputs": {
+        "q": [
+          {
+            "node": 10
+          },
+          {
+            "node": 11
+          },
+          {
+            "node": 12
+          },
+          {
+            "node": 13
+          },
+          {
+            "node": 14
+          },
+          {
+            "node": 15
+          },
+          {
+            "node": 16
+          },
+          {
+            "node": 17
+          }
+        ]
+      },
+      "states": [
+        {
+          "name": "state_reg",
+          "bits": [
+            {
+              "net": "q",
+              "bit": 0,
+              "q": {
+                "node": 10
+              },
+              "d": {
+                "node": 20
+              }
+            },
+            {
+              "net": "q",
+              "bit": 1,
+              "q": {
+                "node": 11
+              },
+              "d": {
+                "node": 23
+              }
+            },
+            {
+              "net": "q",
+              "bit": 2,
+              "q": {
+                "node": 12
+              },
+              "d": {
+                "node": 26
+              }
+            },
+            {
+              "net": "q",
+              "bit": 3,
+              "q": {
+                "node": 13
+              },
+              "d": {
+                "node": 29
+              }
+            },
+            {
+              "net": "q",
+              "bit": 4,
+              "q": {
+                "node": 14
+              },
+              "d": {
+                "node": 32
+              }
+            },
+            {
+              "net": "q",
+              "bit": 5,
+              "q": {
+                "node": 15
+              },
+              "d": {
+                "node": 35
+              }
+            },
+            {
+              "net": "q",
+              "bit": 6,
+              "q": {
+                "node": 16
+              },
+              "d": {
+                "node": 38
+              }
+            },
+            {
+              "net": "q",
+              "bit": 7,
+              "q": {
+                "node": 17
+              },
+              "d": {
+                "node": 41
+              }
+            }
+          ]
+        }
+      ],
+      "nodes": [
+        {
+          "width": 1,
+          "id": 0,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 1,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 2,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 3,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 4,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 5,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 6,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 7,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 8,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 9,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 10,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 11,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 12,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 13,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 14,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 15,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 16,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 17,
+          "kind": {
+            "kind": "input"
+          }
+        },
+        {
+          "width": 1,
+          "id": 18,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 10
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 19,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 1
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 20,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 18
+              },
+              {
+                "node": 19
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 21,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 11
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 22,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 2
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 23,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 21
+              },
+              {
+                "node": 22
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 24,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 12
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 25,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 3
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 26,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 24
+              },
+              {
+                "node": 25
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 27,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 13
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 28,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 4
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 29,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 27
+              },
+              {
+                "node": 28
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 30,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 14
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 31,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 5
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 32,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 30
+              },
+              {
+                "node": 31
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 33,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 15
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 34,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 6
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 35,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 33
+              },
+              {
+                "node": 34
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 36,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 16
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 37,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 7
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 38,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 36
+              },
+              {
+                "node": 37
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 39,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 9,
+                "inverted": true
+              },
+              {
+                "node": 17
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 40,
+          "kind": {
+            "kind": "op",
+            "op": "AND",
+            "inputs": [
+              {
+                "node": 8
+              },
+              {
+                "node": 9
+              }
+            ]
+          }
+        },
+        {
+          "width": 1,
+          "id": 41,
+          "kind": {
+            "kind": "op",
+            "op": "OR",
+            "inputs": [
+              {
+                "node": 39
+              },
+              {
+                "node": 40
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement a NIR normalization pass that builds a structural hash and exposes the serialized form
- add integration tests that normalize fa1, alu4, and reg1x8 NIR inputs and snapshot the results
- check in the corresponding NIR fixtures and insta snapshots under tests/golden/nir

## Testing
- cargo test -p v2m-nir

------
https://chatgpt.com/codex/tasks/task_e_68c9c42929648323a59026c985931c00