### PR TITLE
Implement comb evaluation harness with tests

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
 name = "v2m-evaluator"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "thiserror",
  "v2m-formats",
  "v2m-nir",

--- a/v2m/evaluator/Cargo.toml
+++ b/v2m/evaluator/Cargo.toml
@@ -8,3 +8,6 @@ license = "MIT"
 v2m-formats = { path = "../core/formats" }
 v2m-nir = { path = "../core/nir" }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/v2m/evaluator/src/lib.rs
+++ b/v2m/evaluator/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use thiserror::Error;
-use v2m_formats::nir::{Module, Nir, NodeOp, PortDirection};
+use v2m_formats::nir::{BitRef, Module, Nir, NodeOp, PortDirection};
 use v2m_nir::{BuildError as GraphBuildError, EvalOrderError, ModuleGraph, NodeId};
 
 const WORD_BITS: usize = 64;
@@ -94,6 +94,7 @@ pub struct Evaluator<'nir> {
     input_ports: HashMap<String, PackedIndex>,
     outputs: Packed,
     output_ports: HashMap<String, PackedIndex>,
+    comb_kernels: HashMap<NodeId, NodeKernel>,
 }
 
 impl Packed {
@@ -228,9 +229,105 @@ impl PackedBitMask {
     }
 }
 
+#[derive(Clone, Debug)]
+struct ConstKernel {
+    output: PackedIndex,
+    words: Vec<u64>,
+}
+
+#[derive(Clone, Debug)]
+struct UnaryKernel {
+    input: PackedIndex,
+    output: PackedIndex,
+}
+
+#[derive(Clone, Debug)]
+struct BinaryKernel {
+    input_a: PackedIndex,
+    input_b: PackedIndex,
+    output: PackedIndex,
+}
+
+#[derive(Clone, Debug)]
+enum NodeKernel {
+    Const(ConstKernel),
+    Not(UnaryKernel),
+    And(BinaryKernel),
+}
+
+fn bitref_full_net<'a>(bitref: &'a BitRef, expected_width: u32) -> Option<&'a str> {
+    match bitref {
+        BitRef::Net(net) if net.lsb == 0 && net.msb >= net.lsb => {
+            let width = net.msb - net.lsb + 1;
+            if width == expected_width {
+                Some(net.net.as_str())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn mask_for_word(word_index: usize, words_per_lane: usize, num_vectors: usize) -> u64 {
+    if words_per_lane == 0 {
+        return 0;
+    }
+
+    if word_index + 1 < words_per_lane {
+        return u64::MAX;
+    }
+
+    let remainder = num_vectors % WORD_BITS;
+    if remainder == 0 {
+        if num_vectors == 0 {
+            0
+        } else {
+            u64::MAX
+        }
+    } else {
+        (1u64 << remainder) - 1
+    }
+}
+
+fn parse_const_bool(literal: &str) -> Option<bool> {
+    let cleaned: String = literal.chars().filter(|c| *c != '_').collect();
+    if cleaned.is_empty() {
+        return None;
+    }
+
+    let (base, digits) = if let Some(rest) = cleaned.strip_prefix("0b") {
+        (2, rest)
+    } else if let Some(rest) = cleaned.strip_prefix("0B") {
+        (2, rest)
+    } else if let Some(rest) = cleaned.strip_prefix("0x") {
+        (16, rest)
+    } else if let Some(rest) = cleaned.strip_prefix("0X") {
+        (16, rest)
+    } else {
+        (10, cleaned.as_str())
+    };
+
+    if digits.is_empty() {
+        return None;
+    }
+
+    let value = u128::from_str_radix(digits, base).ok()?;
+    if value > 1 {
+        return None;
+    }
+
+    Some(value == 1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
+    use std::collections::BTreeMap;
+    use v2m_formats::nir::{
+        BitRef, BitRefNet, Module as NirModule, Net as NirNet, Node as NirNode, Port as NirPort,
+    };
 
     #[test]
     fn packed_lane_and_word_indexing() {
@@ -307,6 +404,237 @@ mod tests {
         let empty_mask = PackedBitMask::new(0);
         assert!(empty_mask.words().is_empty());
     }
+
+    fn net_bit(name: &str) -> BitRef {
+        BitRef::Net(BitRefNet {
+            net: name.to_string(),
+            lsb: 0,
+            msb: 0,
+        })
+    }
+
+    fn build_nir(module: NirModule) -> Nir {
+        Nir {
+            v: "nir-1.1".to_string(),
+            design: "test".to_string(),
+            top: "Top".to_string(),
+            attrs: None,
+            modules: BTreeMap::from([("Top".to_string(), module)]),
+            generator: None,
+            cmdline: None,
+            source_digest_sha256: None,
+        }
+    }
+
+    #[test]
+    fn comb_eval_const_node_drives_output() {
+        let mut ports = BTreeMap::new();
+        ports.insert(
+            "y".to_string(),
+            NirPort {
+                dir: PortDirection::Output,
+                bits: 1,
+                attrs: None,
+            },
+        );
+
+        let mut nets = BTreeMap::new();
+        nets.insert(
+            "y".to_string(),
+            NirNet {
+                bits: 1,
+                attrs: None,
+            },
+        );
+
+        let mut params = BTreeMap::new();
+        params.insert("value".to_string(), Value::String("1".to_string()));
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            "const0".to_string(),
+            NirNode {
+                uid: "const0".to_string(),
+                op: NodeOp::Const,
+                width: 1,
+                pin_map: BTreeMap::from([("Y".to_string(), net_bit("y"))]),
+                params: Some(params),
+                attrs: None,
+            },
+        );
+
+        let module = NirModule { ports, nets, nodes };
+        let nir = build_nir(module);
+
+        let mut eval = Evaluator::new(&nir, 70, SimOptions::default()).expect("create evaluator");
+        eval.comb_eval().expect("comb eval");
+
+        let output_index = *eval.output_ports.get("y").expect("output port");
+        let outputs = eval.get_outputs();
+        let words = outputs.slice(output_index);
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0], u64::MAX);
+        let expected_mask = mask_for_word(1, outputs.words_per_lane(), 70);
+        assert_eq!(words[1], expected_mask);
+    }
+
+    #[test]
+    fn comb_eval_not_gate_inverts_input() {
+        let mut ports = BTreeMap::new();
+        ports.insert(
+            "a".to_string(),
+            NirPort {
+                dir: PortDirection::Input,
+                bits: 1,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "y".to_string(),
+            NirPort {
+                dir: PortDirection::Output,
+                bits: 1,
+                attrs: None,
+            },
+        );
+
+        let mut nets = BTreeMap::new();
+        nets.insert(
+            "a".to_string(),
+            NirNet {
+                bits: 1,
+                attrs: None,
+            },
+        );
+        nets.insert(
+            "y".to_string(),
+            NirNet {
+                bits: 1,
+                attrs: None,
+            },
+        );
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            "not0".to_string(),
+            NirNode {
+                uid: "not0".to_string(),
+                op: NodeOp::Not,
+                width: 1,
+                pin_map: BTreeMap::from([
+                    ("A".to_string(), net_bit("a")),
+                    ("Y".to_string(), net_bit("y")),
+                ]),
+                params: None,
+                attrs: None,
+            },
+        );
+
+        let module = NirModule { ports, nets, nodes };
+        let nir = build_nir(module);
+
+        let mut eval = Evaluator::new(&nir, 64, SimOptions::default()).expect("create evaluator");
+
+        let mut inputs = Packed::new(64);
+        let input_index = inputs.allocate(1);
+        inputs.lane_mut(input_index, 0)[0] = 0xAA55_AA55_AA55_AA55u64;
+
+        eval.set_inputs(&inputs).expect("set inputs");
+        eval.comb_eval().expect("comb eval");
+
+        let output_index = *eval.output_ports.get("y").expect("output port");
+        let outputs = eval.get_outputs();
+        let value = outputs.lane(output_index, 0)[0];
+        assert_eq!(value, !0xAA55_AA55_AA55_AA55u64);
+    }
+
+    #[test]
+    fn comb_eval_and_gate_masks_inputs() {
+        let mut ports = BTreeMap::new();
+        ports.insert(
+            "a".to_string(),
+            NirPort {
+                dir: PortDirection::Input,
+                bits: 1,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "b".to_string(),
+            NirPort {
+                dir: PortDirection::Input,
+                bits: 1,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "y".to_string(),
+            NirPort {
+                dir: PortDirection::Output,
+                bits: 1,
+                attrs: None,
+            },
+        );
+
+        let mut nets = BTreeMap::new();
+        nets.insert(
+            "a".to_string(),
+            NirNet {
+                bits: 1,
+                attrs: None,
+            },
+        );
+        nets.insert(
+            "b".to_string(),
+            NirNet {
+                bits: 1,
+                attrs: None,
+            },
+        );
+        nets.insert(
+            "y".to_string(),
+            NirNet {
+                bits: 1,
+                attrs: None,
+            },
+        );
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            "and0".to_string(),
+            NirNode {
+                uid: "and0".to_string(),
+                op: NodeOp::And,
+                width: 1,
+                pin_map: BTreeMap::from([
+                    ("A".to_string(), net_bit("a")),
+                    ("B".to_string(), net_bit("b")),
+                    ("Y".to_string(), net_bit("y")),
+                ]),
+                params: None,
+                attrs: None,
+            },
+        );
+
+        let module = NirModule { ports, nets, nodes };
+        let nir = build_nir(module);
+
+        let mut eval = Evaluator::new(&nir, 64, SimOptions::default()).expect("create evaluator");
+
+        let mut inputs = Packed::new(64);
+        let input_a = inputs.allocate(1);
+        let input_b = inputs.allocate(1);
+        inputs.lane_mut(input_a, 0)[0] = 0xFFFF_0000_FFFF_0000u64;
+        inputs.lane_mut(input_b, 0)[0] = 0x0F0F_0F0F_0F0F_0F0Fu64;
+
+        eval.set_inputs(&inputs).expect("set inputs");
+        eval.comb_eval().expect("comb eval");
+
+        let output_index = *eval.output_ports.get("y").expect("output port");
+        let outputs = eval.get_outputs();
+        let value = outputs.lane(output_index, 0)[0];
+        assert_eq!(value, 0xFFFF_0000_FFFF_0000u64 & 0x0F0F_0F0F_0F0F_0F0Fu64);
+    }
 }
 
 impl<'nir> Evaluator<'nir> {
@@ -365,6 +693,14 @@ impl<'nir> Evaluator<'nir> {
             }
         }
 
+        let comb_kernels = Self::build_comb_kernels(
+            module,
+            &graph,
+            &net_indices,
+            nets.words_per_lane(),
+            num_vectors,
+        );
+
         Ok(Self {
             nir,
             module,
@@ -383,6 +719,7 @@ impl<'nir> Evaluator<'nir> {
             input_ports,
             outputs,
             output_ports,
+            comb_kernels,
         })
     }
 
@@ -392,8 +729,217 @@ impl<'nir> Evaluator<'nir> {
     }
 
     pub fn comb_eval(&mut self) -> Result<(), Error> {
-        // Implementation to be added in a future revision.
+        self.stage_inputs();
+
+        let levels = self.topo_level_offsets.len().saturating_sub(1);
+        for level in 0..levels {
+            let start = self.topo_level_offsets[level];
+            let end = self.topo_level_offsets[level + 1];
+            let level_nodes: Vec<NodeId> = self.topo[start..end].to_vec();
+            for node_id in level_nodes {
+                let kernel = self.comb_kernels.get(&node_id).cloned();
+                if let Some(kernel) = kernel {
+                    self.execute_kernel(&kernel);
+                }
+            }
+        }
+
+        self.stage_outputs();
         Ok(())
+    }
+
+    fn stage_inputs(&mut self) {
+        for (port_name, &port_index) in &self.input_ports {
+            if let Some(&net_index) = self.net_indices.get(port_name.as_str()) {
+                let values = self.inputs.slice(port_index).to_vec();
+                self.nets.slice_mut(net_index).copy_from_slice(&values);
+            }
+        }
+    }
+
+    fn stage_outputs(&mut self) {
+        for (port_name, &port_index) in &self.output_ports {
+            if let Some(&net_index) = self.net_indices.get(port_name.as_str()) {
+                let values = self.nets.slice(net_index).to_vec();
+                self.outputs.slice_mut(port_index).copy_from_slice(&values);
+            }
+        }
+    }
+
+    fn execute_kernel(&mut self, kernel: &NodeKernel) {
+        match kernel {
+            NodeKernel::Const(kernel) => self.run_const(kernel),
+            NodeKernel::Not(kernel) => self.run_not(kernel),
+            NodeKernel::And(kernel) => self.run_and(kernel),
+        }
+    }
+
+    fn run_const(&mut self, kernel: &ConstKernel) {
+        let slice = self.nets.slice_mut(kernel.output);
+        slice.copy_from_slice(&kernel.words);
+    }
+
+    fn run_not(&mut self, kernel: &UnaryKernel) {
+        let words_per_lane = self.nets.words_per_lane();
+        if words_per_lane == 0 {
+            return;
+        }
+
+        let input_words = self.nets.slice(kernel.input).to_vec();
+        let output_slice = self.nets.slice_mut(kernel.output);
+        for (index, word) in output_slice.iter_mut().enumerate() {
+            let lane_word = index % words_per_lane;
+            let mask = mask_for_word(lane_word, words_per_lane, self.num_vectors);
+            *word = (!input_words[index]) & mask;
+        }
+    }
+
+    fn run_and(&mut self, kernel: &BinaryKernel) {
+        let words_per_lane = self.nets.words_per_lane();
+        if words_per_lane == 0 {
+            return;
+        }
+
+        let input_a = self.nets.slice(kernel.input_a).to_vec();
+        let input_b = self.nets.slice(kernel.input_b).to_vec();
+        let output_slice = self.nets.slice_mut(kernel.output);
+        for (index, word) in output_slice.iter_mut().enumerate() {
+            let lane_word = index % words_per_lane;
+            let mask = mask_for_word(lane_word, words_per_lane, self.num_vectors);
+            *word = (input_a[index] & input_b[index]) & mask;
+        }
+    }
+
+    fn build_comb_kernels(
+        module: &'nir Module,
+        graph: &ModuleGraph,
+        net_indices: &HashMap<String, PackedIndex>,
+        words_per_lane: usize,
+        num_vectors: usize,
+    ) -> HashMap<NodeId, NodeKernel> {
+        let mut kernels = HashMap::new();
+
+        for (name, node) in &module.nodes {
+            if matches!(node.op, NodeOp::Dff | NodeOp::Latch) {
+                continue;
+            }
+
+            let node_id = graph
+                .node_id(name.as_str())
+                .expect("module node must exist in graph");
+
+            let kernel = match node.op {
+                NodeOp::Const => {
+                    Self::build_const_kernel(node, net_indices, words_per_lane, num_vectors)
+                        .map(NodeKernel::Const)
+                }
+                NodeOp::Not => Self::build_not_kernel(node, net_indices).map(NodeKernel::Not),
+                NodeOp::And => Self::build_and_kernel(node, net_indices).map(NodeKernel::And),
+                _ => None,
+            };
+
+            if let Some(kernel) = kernel {
+                kernels.insert(node_id, kernel);
+            }
+        }
+
+        kernels
+    }
+
+    fn build_const_kernel(
+        node: &v2m_formats::nir::Node,
+        net_indices: &HashMap<String, PackedIndex>,
+        words_per_lane: usize,
+        num_vectors: usize,
+    ) -> Option<ConstKernel> {
+        if node.width != 1 {
+            return None;
+        }
+
+        let output_ref = node.pin_map.get("Y").expect("CONST node must bind Y pin");
+        let output_net = bitref_full_net(output_ref, node.width)?;
+        let output_index = *net_indices
+            .get(output_net)
+            .expect("CONST node output net must be allocated");
+
+        let literal = node
+            .params
+            .as_ref()
+            .and_then(|params| params.get("value"))
+            .and_then(|value| value.as_str())
+            .expect("CONST node requires string `value` parameter");
+        let bit_value =
+            parse_const_bool(literal).expect("CONST node value must fit within one bit");
+
+        let mut words = Vec::with_capacity(output_index.lanes() * words_per_lane);
+        if words_per_lane == 0 {
+            return Some(ConstKernel {
+                output: output_index,
+                words,
+            });
+        }
+
+        for _ in 0..output_index.lanes() {
+            for word_index in 0..words_per_lane {
+                let mask = mask_for_word(word_index, words_per_lane, num_vectors);
+                let value = if bit_value { mask } else { 0 };
+                words.push(value);
+            }
+        }
+
+        Some(ConstKernel {
+            output: output_index,
+            words,
+        })
+    }
+
+    fn build_not_kernel(
+        node: &v2m_formats::nir::Node,
+        net_indices: &HashMap<String, PackedIndex>,
+    ) -> Option<UnaryKernel> {
+        let input_ref = node.pin_map.get("A")?;
+        let output_ref = node.pin_map.get("Y")?;
+        let input_net = bitref_full_net(input_ref, node.width)?;
+        let output_net = bitref_full_net(output_ref, node.width)?;
+        let input_index = *net_indices
+            .get(input_net)
+            .expect("NOT input net must be allocated");
+        let output_index = *net_indices
+            .get(output_net)
+            .expect("NOT output net must be allocated");
+
+        Some(UnaryKernel {
+            input: input_index,
+            output: output_index,
+        })
+    }
+
+    fn build_and_kernel(
+        node: &v2m_formats::nir::Node,
+        net_indices: &HashMap<String, PackedIndex>,
+    ) -> Option<BinaryKernel> {
+        let input_a_ref = node.pin_map.get("A")?;
+        let input_b_ref = node.pin_map.get("B")?;
+        let output_ref = node.pin_map.get("Y")?;
+        let input_a_net = bitref_full_net(input_a_ref, node.width)?;
+        let input_b_net = bitref_full_net(input_b_ref, node.width)?;
+        let output_net = bitref_full_net(output_ref, node.width)?;
+
+        let input_a = *net_indices
+            .get(input_a_net)
+            .expect("AND A input net must be allocated");
+        let input_b = *net_indices
+            .get(input_b_net)
+            .expect("AND B input net must be allocated");
+        let output = *net_indices
+            .get(output_net)
+            .expect("AND output net must be allocated");
+
+        Some(BinaryKernel {
+            input_a,
+            input_b,
+            output,
+        })
     }
 
     pub fn step_clock(&mut self, _reset_mask: &PackedBitMask) -> Result<(), Error> {


### PR DESCRIPTION
## Summary
- build combinational kernels for const/not/and nodes and stage port data before/after evaluation
- execute kernels in topological order during `comb_eval` and store precomputed kernel metadata
- add smoke tests covering const, not, and gates and include serde_json as a dev dependency

## Testing
- cargo test -p v2m-evaluator

------
https://chatgpt.com/codex/tasks/task_e_68c9ca9530548323b289262aa36661e0