### PR TITLE
Add AoS/SoA packing utilities and tests

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -512,6 +512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +543,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -781,6 +820,9 @@ dependencies = [
 name = "v2m-evaluator"
 version = "0.1.0"
 dependencies = [
+ "num-bigint",
+ "num-traits",
+ "rand",
  "thiserror",
  "v2m-formats",
  "v2m-nir",

--- a/v2m/docs/evaluator-v2.md
+++ b/v2m/docs/evaluator-v2.md
@@ -31,14 +31,14 @@ Evaluator v2 operates on *batches* of stimulus vectors. A batch size is the numb
 
 Two axes control the packed representation of a signal:
 
-* **Bit lanes** — a `width`-bit signal requires `L = ceil(width / 64)` lanes. A lane stores up to 64 adjacent bits from the signal.
+* **Bit lanes** — a `width`-bit signal requires `L = width` lanes. Each lane tracks a single bit from the signal across all vectors.
 * **Vector words** — `N` vectors are processed in groups of 64, yielding `W = ceil(N / 64)` words per lane. Each bit inside a word is one vector.
 
 The storage for a signal therefore forms an `L × W` matrix of `u64`. All logic kernels operate on this matrix layout.
 
 ### Packed storage
 
-`Packed` is the reusable storage arena for these matrices. A `Packed` value owns an SoA buffer sized for a specific batch. Slices inside the arena are described by `PackedIndex`, which stores the offset and lane count for a signal. The same index can be reused across multiple `Packed` values that share a layout (for example the current and next register images).
+`Packed` is the reusable storage arena for these matrices. A `Packed` value owns an SoA buffer sized for a specific batch. Slices inside the arena are described by `PackedIndex`, which stores the offset and lane count for a signal. The same index can be reused across multiple `Packed` values that share a layout (for example the current and next register images). Because each lane represents a single signal bit, the lane count for a signal matches its bit width.
 
 ```rust
 pub struct Packed {

--- a/v2m/evaluator/Cargo.toml
+++ b/v2m/evaluator/Cargo.toml
@@ -8,3 +8,8 @@ license = "MIT"
 v2m-formats = { path = "../core/formats" }
 v2m-nir = { path = "../core/nir" }
 thiserror = { workspace = true }
+num-bigint = { workspace = true }
+num-traits = "0.2"
+
+[dev-dependencies]
+rand = "0.8"

--- a/v2m/evaluator/src/lib.rs
+++ b/v2m/evaluator/src/lib.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use num_bigint::BigUint;
+use num_traits::Zero;
+
 use thiserror::Error;
 use v2m_formats::nir::{Module, Nir, NodeOp, PortDirection};
 use v2m_nir::{BuildError as GraphBuildError, EvalOrderError, ModuleGraph, NodeId};
@@ -18,7 +21,7 @@ fn div_ceil(value: usize, divisor: usize) -> usize {
 
 #[inline]
 fn lanes_for_width(width_bits: usize) -> usize {
-    div_ceil(width_bits, WORD_BITS)
+    width_bits
 }
 
 #[inline]
@@ -64,6 +67,34 @@ pub enum PackedError {
 }
 
 #[derive(Debug, Error)]
+pub enum PortValueError {
+    #[error("missing data for port `{name}`")]
+    MissingPort { name: String },
+    #[error("unexpected port `{name}`")]
+    UnexpectedPort { name: String },
+    #[error("port `{name}` expects {expected} vectors, got {actual}")]
+    VectorCountMismatch {
+        name: String,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("value for port `{name}` vector {vector} exceeds width {width_bits} bits")]
+    ValueTooWide {
+        name: String,
+        width_bits: usize,
+        vector: usize,
+    },
+    #[error("packed buffer expects {expected} vectors, got {actual}")]
+    PackedVectorMismatch { expected: usize, actual: usize },
+    #[error("packed buffer words-per-lane mismatch (expected {expected}, got {actual})")]
+    WordsPerLaneMismatch { expected: usize, actual: usize },
+    #[error("packed buffer layout mismatch for port `{name}`")]
+    PackedLayoutMismatch { name: String },
+    #[error("port `{name}` has unsupported direction `{actual:?}` for this operation")]
+    DirectionMismatch { name: String, actual: PortDirection },
+}
+
+#[derive(Debug, Error)]
 pub enum Error {
     #[error("top module `{top}` not found in design `{design}`")]
     MissingTop { design: String, top: String },
@@ -73,6 +104,8 @@ pub enum Error {
     EvalOrder(#[from] EvalOrderError),
     #[error(transparent)]
     Packed(#[from] PackedError),
+    #[error(transparent)]
+    PortValues(#[from] PortValueError),
 }
 
 #[allow(dead_code)]
@@ -226,9 +259,271 @@ impl PackedBitMask {
     }
 }
 
+fn pack_port_biguints(
+    target: &mut Packed,
+    index: PackedIndex,
+    width_bits: usize,
+    values: &[BigUint],
+    name: &str,
+) -> Result<(), PortValueError> {
+    if width_bits > index.lanes() {
+        return Err(PortValueError::PackedLayoutMismatch {
+            name: name.to_string(),
+        });
+    }
+
+    if values.len() != target.num_vectors() {
+        return Err(PortValueError::VectorCountMismatch {
+            name: name.to_string(),
+            expected: target.num_vectors(),
+            actual: values.len(),
+        });
+    }
+
+    let words_per_lane = target.words_per_lane();
+    let slice = target.slice_mut(index);
+    slice.fill(0);
+
+    if width_bits == 0 {
+        for (vec_idx, value) in values.iter().enumerate() {
+            if !value.is_zero() {
+                return Err(PortValueError::ValueTooWide {
+                    name: name.to_string(),
+                    width_bits,
+                    vector: vec_idx,
+                });
+            }
+        }
+        return Ok(());
+    }
+
+    for (vec_idx, value) in values.iter().enumerate() {
+        if value.bits() > width_bits as u64 {
+            return Err(PortValueError::ValueTooWide {
+                name: name.to_string(),
+                width_bits,
+                vector: vec_idx,
+            });
+        }
+
+        if value.is_zero() {
+            continue;
+        }
+
+        let word_idx = vec_idx / WORD_BITS;
+        let bit_in_word = vec_idx % WORD_BITS;
+        let bit_mask = 1u64 << bit_in_word;
+
+        for (chunk_idx, mut chunk) in value.to_u64_digits().into_iter().enumerate() {
+            if chunk == 0 {
+                continue;
+            }
+
+            let base_lane = chunk_idx * WORD_BITS;
+            while chunk != 0 {
+                let bit = chunk.trailing_zeros() as usize;
+                let lane = base_lane + bit;
+                if lane >= width_bits {
+                    break;
+                }
+
+                let offset = index.offset + lane * words_per_lane + word_idx;
+                target.storage[offset] |= bit_mask;
+                chunk &= chunk - 1;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn unpack_port_biguints(
+    source: &Packed,
+    index: PackedIndex,
+    width_bits: usize,
+    name: &str,
+) -> Result<Vec<BigUint>, PortValueError> {
+    if width_bits > index.lanes() {
+        return Err(PortValueError::PackedLayoutMismatch {
+            name: name.to_string(),
+        });
+    }
+
+    let words_per_lane = source.words_per_lane();
+    let end = index.offset + index.lanes() * words_per_lane;
+    if end > source.storage.len() {
+        return Err(PortValueError::PackedLayoutMismatch {
+            name: name.to_string(),
+        });
+    }
+
+    let num_vectors = source.num_vectors();
+    let mut result = vec![BigUint::default(); num_vectors];
+
+    if width_bits == 0 {
+        return Ok(result);
+    }
+
+    let slice = source.slice(index);
+    for lane in 0..width_bits {
+        let lane_offset = lane * words_per_lane;
+        for word_idx in 0..words_per_lane {
+            let word = slice[lane_offset + word_idx];
+            if word == 0 {
+                continue;
+            }
+
+            let base_vector = word_idx * WORD_BITS;
+            let mut mask = word;
+            while mask != 0 {
+                let bit = mask.trailing_zeros() as usize;
+                let vector_idx = base_vector + bit;
+                if vector_idx >= num_vectors {
+                    break;
+                }
+
+                result[vector_idx].set_bit(lane as u64, true);
+                mask &= mask - 1;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use std::collections::{BTreeMap, HashMap};
+    use v2m_formats::nir::Port;
+
+    fn build_test_nir() -> Nir {
+        let mut ports = BTreeMap::new();
+        ports.insert(
+            "a".to_string(),
+            Port {
+                dir: PortDirection::Input,
+                bits: 1,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "b".to_string(),
+            Port {
+                dir: PortDirection::Input,
+                bits: 17,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "c".to_string(),
+            Port {
+                dir: PortDirection::Inout,
+                bits: 65,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "zero_in".to_string(),
+            Port {
+                dir: PortDirection::Input,
+                bits: 0,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "y".to_string(),
+            Port {
+                dir: PortDirection::Output,
+                bits: 7,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "z".to_string(),
+            Port {
+                dir: PortDirection::Output,
+                bits: 128,
+                attrs: None,
+            },
+        );
+        ports.insert(
+            "zero_out".to_string(),
+            Port {
+                dir: PortDirection::Output,
+                bits: 0,
+                attrs: None,
+            },
+        );
+
+        let module = Module {
+            ports,
+            nets: BTreeMap::new(),
+            nodes: BTreeMap::new(),
+        };
+
+        let mut modules = BTreeMap::new();
+        modules.insert("top".to_string(), module);
+
+        Nir {
+            v: "0.1".to_string(),
+            design: "test".to_string(),
+            top: "top".to_string(),
+            attrs: None,
+            modules,
+            generator: None,
+            cmdline: None,
+            source_digest_sha256: None,
+        }
+    }
+
+    fn random_biguint(width_bits: usize, rng: &mut StdRng) -> BigUint {
+        if width_bits == 0 {
+            return BigUint::default();
+        }
+
+        let byte_len = div_ceil(width_bits, 8);
+        let mut bytes = vec![0u8; byte_len];
+        rng.fill_bytes(&mut bytes);
+
+        let excess_bits = byte_len * 8 - width_bits;
+        if excess_bits > 0 {
+            let keep = 8 - excess_bits;
+            let mask = if keep == 0 {
+                0
+            } else {
+                ((1u16 << keep) - 1) as u8
+            };
+            if let Some(last) = bytes.last_mut() {
+                *last &= mask;
+            }
+        }
+
+        BigUint::from_bytes_le(&bytes)
+    }
+
+    fn random_biguints(width_bits: usize, count: usize, rng: &mut StdRng) -> Vec<BigUint> {
+        (0..count)
+            .map(|_| random_biguint(width_bits, rng))
+            .collect()
+    }
+
+    fn biguints_to_fixed_bytes(values: &[BigUint], width_bits: usize) -> Vec<Vec<u8>> {
+        let byte_len = div_ceil(width_bits, 8);
+        values
+            .iter()
+            .map(|value| {
+                let mut bytes = value.to_bytes_le();
+                if bytes.len() < byte_len {
+                    bytes.resize(byte_len, 0);
+                } else if bytes.len() > byte_len {
+                    bytes.truncate(byte_len);
+                }
+                bytes
+            })
+            .collect()
+    }
 
     #[test]
     fn packed_lane_and_word_indexing() {
@@ -237,10 +532,10 @@ mod tests {
 
         let first = packed.allocate(96);
         assert_eq!(first.offset(), 0);
-        assert_eq!(first.lanes(), 2);
+        assert_eq!(first.lanes(), 96);
 
         let second = packed.allocate(32);
-        assert_eq!(second.lanes(), 1);
+        assert_eq!(second.lanes(), 32);
         assert_eq!(
             second.offset(),
             first.offset() + first.lanes() * packed.words_per_lane()
@@ -263,12 +558,23 @@ mod tests {
         assert_eq!(packed.total_lanes(), first.lanes() + second.lanes());
         assert_eq!(packed.lane(first, 0), &[0, 1]);
         assert_eq!(packed.lane(first, 1), &[0x0001_0000, 0x0001_0001]);
-        assert_eq!(packed.slice(first), &[0, 1, 0x0001_0000, 0x0001_0001]);
-        assert_eq!(packed.slice(second), &[0xABCD_0000, 0xABCD_0001]);
+        assert_eq!(packed.lane(first, 95), &[0x005F_0000, 0x005F_0001]);
+
+        let slice = packed.slice(first);
+        assert_eq!(&slice[0..4], &[0, 1, 0x0001_0000, 0x0001_0001]);
+        let tail_start = (first.lanes() - 1) * packed.words_per_lane();
+        assert_eq!(
+            &slice[tail_start..tail_start + packed.words_per_lane()],
+            &[0x005F_0000, 0x005F_0001]
+        );
+        assert_eq!(packed.lane(second, 0), &[0xABCD_0000, 0xABCD_0001]);
 
         let words_per_lane = packed.words_per_lane();
         assert_eq!(first.lane_offset(1, words_per_lane), words_per_lane);
-        assert_eq!(first.word_offset(1, 1, words_per_lane), words_per_lane + 1);
+        assert_eq!(
+            first.word_offset(first.lanes() - 1, 1, words_per_lane),
+            (first.lanes() - 1) * words_per_lane + 1
+        );
     }
 
     #[test]
@@ -277,14 +583,18 @@ mod tests {
         assert_eq!(packed.words_per_lane(), 2);
 
         let index = packed.allocate(65);
-        assert_eq!(index.lanes(), 2);
-        assert_eq!(packed.slice(index).len(), 4);
+        assert_eq!(index.lanes(), 65);
+        assert_eq!(packed.slice(index).len(), 130);
 
-        packed.lane_mut(index, 1)[1] = 0xFFFF_FFFF_FFFFu64;
+        packed.lane_mut(index, 64)[1] = 0xFFFF_FFFF_FFFFu64;
 
-        assert_eq!(packed.lane(index, 1)[1], 0xFFFF_FFFF_FFFFu64);
-        assert_eq!(packed.slice(index)[3], 0xFFFF_FFFF_FFFFu64);
-        assert!(packed.slice(index)[0..3].iter().all(|&word| word == 0));
+        let lane = packed.lane(index, 64);
+        assert_eq!(lane[1], 0xFFFF_FFFF_FFFFu64);
+
+        let slice = packed.slice(index);
+        let start = 64 * packed.words_per_lane();
+        assert_eq!(slice[start + 1], 0xFFFF_FFFF_FFFFu64);
+        assert!(slice[..start + 1].iter().all(|&word| word == 0));
     }
 
     #[test]
@@ -304,6 +614,136 @@ mod tests {
 
         let empty_mask = PackedBitMask::new(0);
         assert!(empty_mask.words().is_empty());
+    }
+
+    #[test]
+    fn inputs_packing_round_trip() {
+        let nir = build_test_nir();
+        let num_vectors = 130;
+        let evaluator = Evaluator::new(&nir, num_vectors, SimOptions::default()).unwrap();
+        let mut rng = StdRng::seed_from_u64(0xDEADBEEF);
+
+        let mut biguint_inputs: HashMap<String, Vec<BigUint>> = HashMap::new();
+        for (name, port) in &evaluator.module.ports {
+            if matches!(port.dir, PortDirection::Input | PortDirection::Inout) {
+                let values = random_biguints(port.bits as usize, num_vectors, &mut rng);
+                biguint_inputs.insert(name.clone(), values);
+            }
+        }
+
+        let packed_biguint = evaluator
+            .pack_inputs_from_biguints(&biguint_inputs)
+            .expect("packing inputs from bigints should succeed");
+
+        for (name, index) in &evaluator.input_ports {
+            let width = evaluator.module.ports[name].bits as usize;
+            let expected = &biguint_inputs[name];
+            let actual = unpack_port_biguints(&packed_biguint, *index, width, name)
+                .expect("unpacking should succeed");
+            assert_eq!(&actual, expected);
+        }
+
+        let mut byte_inputs: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        for (name, values) in &biguint_inputs {
+            let width = evaluator.module.ports[name].bits as usize;
+            byte_inputs.insert(name.clone(), biguints_to_fixed_bytes(values, width));
+        }
+
+        let packed_bytes = evaluator
+            .pack_inputs_from_bytes(&byte_inputs)
+            .expect("packing inputs from bytes should succeed");
+
+        for index in evaluator.input_ports.values() {
+            assert_eq!(packed_bytes.slice(*index), packed_biguint.slice(*index));
+        }
+    }
+
+    #[test]
+    fn outputs_unpack_round_trip() {
+        let nir = build_test_nir();
+        let num_vectors = 96;
+        let evaluator = Evaluator::new(&nir, num_vectors, SimOptions::default()).unwrap();
+        let mut rng = StdRng::seed_from_u64(0x12345678);
+
+        let mut packed_outputs = evaluator.outputs.duplicate_layout();
+        let mut expected = HashMap::new();
+
+        for (name, index) in &evaluator.output_ports {
+            let width = evaluator.module.ports[name].bits as usize;
+            let values = random_biguints(width, num_vectors, &mut rng);
+            pack_port_biguints(&mut packed_outputs, *index, width, &values, name)
+                .expect("packing test outputs should succeed");
+            expected.insert(name.clone(), values);
+        }
+
+        let bigints = evaluator
+            .unpack_outputs_to_biguints(&packed_outputs)
+            .expect("unpacking bigints should succeed");
+        assert_eq!(bigints, expected);
+
+        let bytes = evaluator
+            .unpack_outputs_to_bytes(&packed_outputs)
+            .expect("unpacking bytes should succeed");
+
+        for (name, values) in &expected {
+            let width = evaluator.module.ports[name].bits as usize;
+            let expected_bytes = biguints_to_fixed_bytes(values, width);
+            assert_eq!(bytes[name], expected_bytes);
+        }
+    }
+
+    #[test]
+    fn packing_reports_errors() {
+        let nir = build_test_nir();
+        let num_vectors = 64;
+        let evaluator = Evaluator::new(&nir, num_vectors, SimOptions::default()).unwrap();
+        let mut rng = StdRng::seed_from_u64(0xCAFEBABE);
+
+        let mut partial_inputs = HashMap::new();
+        partial_inputs.insert("a".to_string(), random_biguints(1, num_vectors, &mut rng));
+        partial_inputs.insert("b".to_string(), random_biguints(17, num_vectors, &mut rng));
+        partial_inputs.insert("zero_in".to_string(), vec![BigUint::default(); num_vectors]);
+
+        let err = evaluator
+            .pack_inputs_from_biguints(&partial_inputs)
+            .unwrap_err();
+        assert!(matches!(err, PortValueError::MissingPort { .. }));
+
+        let mut full_inputs = partial_inputs.clone();
+        full_inputs.insert("c".to_string(), random_biguints(65, num_vectors, &mut rng));
+
+        let mut inputs_with_extra = full_inputs.clone();
+        inputs_with_extra.insert("extra".to_string(), vec![BigUint::default(); num_vectors]);
+        let err = evaluator
+            .pack_inputs_from_biguints(&inputs_with_extra)
+            .unwrap_err();
+        assert!(matches!(err, PortValueError::UnexpectedPort { .. }));
+
+        let mut wrong_len = full_inputs.clone();
+        wrong_len.insert(
+            "c".to_string(),
+            random_biguints(65, num_vectors - 1, &mut rng),
+        );
+        let err = evaluator.pack_inputs_from_biguints(&wrong_len).unwrap_err();
+        assert!(matches!(err, PortValueError::VectorCountMismatch { .. }));
+
+        let mut too_wide = full_inputs;
+        let mut values = random_biguints(65, num_vectors, &mut rng);
+        values[0].set_bit(65, true);
+        too_wide.insert("c".to_string(), values);
+        let err = evaluator.pack_inputs_from_biguints(&too_wide).unwrap_err();
+        assert!(matches!(err, PortValueError::ValueTooWide { .. }));
+    }
+
+    #[test]
+    fn unpacking_detects_vector_mismatch() {
+        let nir = build_test_nir();
+        let evaluator = Evaluator::new(&nir, 32, SimOptions::default()).unwrap();
+        let wrong_vectors = Packed::new(16);
+        let err = evaluator
+            .unpack_outputs_to_biguints(&wrong_vectors)
+            .unwrap_err();
+        assert!(matches!(err, PortValueError::PackedVectorMismatch { .. }));
     }
 }
 
@@ -379,6 +819,166 @@ impl<'nir> Evaluator<'nir> {
             outputs,
             output_ports,
         })
+    }
+
+    pub fn pack_inputs_from_biguints(
+        &self,
+        port_vectors: &HashMap<String, Vec<BigUint>>,
+    ) -> Result<Packed, PortValueError> {
+        let mut packed = self.inputs.duplicate_layout();
+
+        for (name, index) in &self.input_ports {
+            let port = self
+                .module
+                .ports
+                .get(name.as_str())
+                .expect("input port must exist");
+
+            if !matches!(port.dir, PortDirection::Input | PortDirection::Inout) {
+                return Err(PortValueError::DirectionMismatch {
+                    name: name.clone(),
+                    actual: port.dir.clone(),
+                });
+            }
+
+            let values = port_vectors
+                .get(name)
+                .ok_or_else(|| PortValueError::MissingPort { name: name.clone() })?;
+
+            pack_port_biguints(&mut packed, *index, port.bits as usize, values, name)?;
+        }
+
+        for name in port_vectors.keys() {
+            if !self.input_ports.contains_key(name) {
+                return Err(PortValueError::UnexpectedPort { name: name.clone() });
+            }
+        }
+
+        Ok(packed)
+    }
+
+    pub fn pack_inputs_from_bytes(
+        &self,
+        port_vectors: &HashMap<String, Vec<Vec<u8>>>,
+    ) -> Result<Packed, PortValueError> {
+        let mut packed = self.inputs.duplicate_layout();
+
+        for (name, index) in &self.input_ports {
+            let port = self
+                .module
+                .ports
+                .get(name.as_str())
+                .expect("input port must exist");
+
+            if !matches!(port.dir, PortDirection::Input | PortDirection::Inout) {
+                return Err(PortValueError::DirectionMismatch {
+                    name: name.clone(),
+                    actual: port.dir.clone(),
+                });
+            }
+
+            let values = port_vectors
+                .get(name)
+                .ok_or_else(|| PortValueError::MissingPort { name: name.clone() })?;
+
+            if values.len() != self.num_vectors {
+                return Err(PortValueError::VectorCountMismatch {
+                    name: name.clone(),
+                    expected: self.num_vectors,
+                    actual: values.len(),
+                });
+            }
+
+            let mut converted = Vec::with_capacity(values.len());
+            for bytes in values {
+                converted.push(BigUint::from_bytes_le(bytes));
+            }
+
+            pack_port_biguints(&mut packed, *index, port.bits as usize, &converted, name)?;
+        }
+
+        for name in port_vectors.keys() {
+            if !self.input_ports.contains_key(name) {
+                return Err(PortValueError::UnexpectedPort { name: name.clone() });
+            }
+        }
+
+        Ok(packed)
+    }
+
+    pub fn unpack_outputs_to_biguints(
+        &self,
+        outputs: &Packed,
+    ) -> Result<HashMap<String, Vec<BigUint>>, PortValueError> {
+        if outputs.num_vectors() != self.num_vectors {
+            return Err(PortValueError::PackedVectorMismatch {
+                expected: self.num_vectors,
+                actual: outputs.num_vectors(),
+            });
+        }
+
+        let expected_words = self.outputs.words_per_lane();
+        if outputs.words_per_lane() != expected_words {
+            return Err(PortValueError::WordsPerLaneMismatch {
+                expected: expected_words,
+                actual: outputs.words_per_lane(),
+            });
+        }
+
+        let mut result = HashMap::with_capacity(self.output_ports.len());
+
+        for (name, index) in &self.output_ports {
+            let port = self
+                .module
+                .ports
+                .get(name.as_str())
+                .expect("output port must exist");
+
+            if !matches!(port.dir, PortDirection::Output | PortDirection::Inout) {
+                return Err(PortValueError::DirectionMismatch {
+                    name: name.clone(),
+                    actual: port.dir.clone(),
+                });
+            }
+
+            let values = unpack_port_biguints(outputs, *index, port.bits as usize, name)?;
+            result.insert(name.clone(), values);
+        }
+
+        Ok(result)
+    }
+
+    pub fn unpack_outputs_to_bytes(
+        &self,
+        outputs: &Packed,
+    ) -> Result<HashMap<String, Vec<Vec<u8>>>, PortValueError> {
+        let bigints = self.unpack_outputs_to_biguints(outputs)?;
+        let mut result = HashMap::with_capacity(bigints.len());
+
+        for (name, values) in bigints {
+            let width_bits = self
+                .module
+                .ports
+                .get(name.as_str())
+                .expect("output port must exist")
+                .bits as usize;
+            let byte_len = div_ceil(width_bits, 8);
+
+            let mut port_bytes = Vec::with_capacity(values.len());
+            for value in values {
+                let mut bytes = value.to_bytes_le();
+                if bytes.len() < byte_len {
+                    bytes.resize(byte_len, 0);
+                } else if bytes.len() > byte_len {
+                    bytes.truncate(byte_len);
+                }
+                port_bytes.push(bytes);
+            }
+
+            result.insert(name, port_bytes);
+        }
+
+        Ok(result)
     }
 
     pub fn set_inputs(&mut self, port_values: &Packed) -> Result<(), Error> {


### PR DESCRIPTION
## Summary
- add a dedicated `PortValueError` along with helper routines to pack and unpack per-port `BigUint` data into the SoA buffers
- expose evaluator helpers to convert between AoS `BigUint`/byte maps and the packed representation for both inputs and outputs
- extend the test suite with randomized round-trip and error-case coverage for the new pack/unpack helpers
- adjust the packed lane calculation and pull in the bigint/traits/rand dependencies needed for the new utilities

## Testing
- cargo test -p v2m-evaluator

------
https://chatgpt.com/codex/tasks/task_e_68c9c9ce2db08323a833c37eb5186096