### PR TITLE
Implement reset semantics in evaluator

### DIFF
--- a/v2m/evaluator/Cargo.toml
+++ b/v2m/evaluator/Cargo.toml
@@ -10,7 +10,7 @@ v2m-nir = { path = "../core/nir" }
 thiserror = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = "0.2"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 rand = "0.8"
-serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
- add reset metadata parsing for DFF nodes and track register init values
- update step_clock to honor per-vector reset masks for synchronous and asynchronous flops
- extend unit tests to cover reset behaviour and promote serde_json to a normal dependency

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68caee8e84448323bbb515c44cf1741e