### PR TITLE
Add NIR Verilog exporter and Yosys equivalence tests

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "v2m-formats",
 ]

--- a/v2m/core/nir/Cargo.toml
+++ b/v2m/core/nir/Cargo.toml
@@ -13,3 +13,4 @@ serde = { workspace = true }
 [dev-dependencies]
 v2m-formats = { path = "../formats" }
 insta = { workspace = true }
+tempfile = "3"

--- a/v2m/core/nir/src/lib.rs
+++ b/v2m/core/nir/src/lib.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 mod lint;
 mod normalize;
 mod strash;
+mod verilog;
 
 pub use lint::{lint_module, lint_nir, Driver, LintError};
 pub use normalize::{
@@ -13,6 +14,7 @@ pub use normalize::{
     NormalizedNir, NormalizedNode, NormalizedNodeKind, StateBitSnapshot, StateSnapshot,
 };
 pub use strash::{Literal, ParamMap, StrashKind, StrashNode, StrashNodeId, StructuralHasher};
+pub use verilog::{nir_to_verilog, VerilogExportError};
 
 use v2m_formats::nir::{Module, NodeOp};
 use v2m_formats::{resolve_bitref, BitRef, ResolvedBit};

--- a/v2m/core/nir/src/verilog.rs
+++ b/v2m/core/nir/src/verilog.rs
@@ -1,0 +1,507 @@
+use std::collections::BTreeSet;
+use std::fmt::Write;
+
+use thiserror::Error;
+
+use v2m_formats::nir::{BitRef, BitRefConcat, BitRefNet, Module, Nir, Node, NodeOp, PortDirection};
+
+#[derive(Debug, Error)]
+pub enum VerilogExportError {
+    #[error("node `{node}` uses unsupported operation `{op:?}`")]
+    UnsupportedOperation { node: String, op: NodeOp },
+    #[error("node `{node}` is missing required pin `{pin}`")]
+    MissingPin { node: String, pin: String },
+    #[error("node `{node}` pin `{pin}` references unsupported constant destination")]
+    ConstOnOutput { node: String, pin: String },
+    #[error("net `{net}` referenced by node `{node}` is undefined in module")]
+    UnknownNet { node: String, net: String },
+    #[error("failed to format Verilog output: {0}")]
+    FmtError(#[from] std::fmt::Error),
+}
+
+pub fn nir_to_verilog(nir: &Nir) -> Result<String, VerilogExportError> {
+    let mut output = String::new();
+    let mut first = true;
+    for (name, module) in &nir.modules {
+        if !first {
+            output.push_str("\n");
+        }
+        first = false;
+        render_module(&mut output, name, module)?;
+        output.push_str("\n");
+    }
+    Ok(output)
+}
+
+fn render_module(
+    output: &mut String,
+    name: &str,
+    module: &Module,
+) -> Result<(), VerilogExportError> {
+    writeln!(output, "module {}(", name)?;
+
+    let mut port_names: Vec<_> = module.ports.keys().collect();
+    port_names.sort();
+    for (index, port_name) in port_names.iter().enumerate() {
+        let port = module
+            .ports
+            .get(*port_name)
+            .expect("port must exist while iterating names");
+        let dir = match port.dir {
+            PortDirection::Input => "input",
+            PortDirection::Output => "output",
+            PortDirection::Inout => "inout",
+        };
+        let width = format_width(port.bits);
+        let comma = if index + 1 == port_names.len() {
+            ""
+        } else {
+            ","
+        };
+        writeln!(output, "    {} wire {}{}{}", dir, width, port_name, comma)?;
+    }
+    writeln!(output, ");")?;
+    output.push_str("\n");
+
+    let mut wire_names: Vec<_> = module.nets.keys().collect();
+    wire_names.sort();
+
+    let port_set: BTreeSet<_> = module.ports.keys().collect();
+    for net_name in &wire_names {
+        if port_set.contains(net_name) {
+            continue;
+        }
+        let net = module
+            .nets
+            .get(*net_name)
+            .expect("net must exist while iterating names");
+        writeln!(output, "    wire {}{};", format_width(net.bits), net_name)?;
+    }
+
+    let mut sequential = Vec::new();
+    let mut assignments = Vec::new();
+
+    for (node_name, node) in &module.nodes {
+        match node.op {
+            NodeOp::Dff => {
+                sequential.push(collect_dff(node_name, node, module)?);
+            }
+            NodeOp::Latch => {
+                return Err(VerilogExportError::UnsupportedOperation {
+                    node: node_name.clone(),
+                    op: node.op.clone(),
+                });
+            }
+            _ => {
+                assignments.push(collect_assignment(node_name, node, module)?);
+            }
+        }
+    }
+
+    for reg in &sequential {
+        let decl_width = format_width(reg.width);
+        writeln!(output, "    reg {}{};", decl_width, reg.reg_name)?;
+    }
+
+    for assignment in &assignments {
+        writeln!(
+            output,
+            "    assign {} = {};",
+            assignment.lhs, assignment.rhs
+        )?;
+    }
+
+    for reg in &sequential {
+        writeln!(
+            output,
+            "    assign {} = {};",
+            format_lhs(&reg.node_name, module, &reg.q_binding)?,
+            reg.reg_name
+        )?;
+    }
+
+    for reg in &sequential {
+        writeln!(output, "    always @(posedge {}) begin", reg.clk_expr)?;
+        writeln!(output, "        {} <= {};", reg.reg_name, reg.d_expr)?;
+        writeln!(output, "    end")?;
+    }
+
+    writeln!(output, "endmodule")?;
+    Ok(())
+}
+
+struct Assignment {
+    lhs: String,
+    rhs: String,
+}
+
+struct DffExport {
+    reg_name: String,
+    width: u32,
+    node_name: String,
+    q_binding: BitBinding,
+    d_expr: String,
+    clk_expr: String,
+}
+
+type BitBinding = BitRef;
+
+fn collect_assignment(
+    node_name: &str,
+    node: &Node,
+    module: &Module,
+) -> Result<Assignment, VerilogExportError> {
+    let y_pin = node
+        .pin_map
+        .get("Y")
+        .ok_or_else(|| VerilogExportError::MissingPin {
+            node: node_name.to_string(),
+            pin: "Y".to_string(),
+        })?;
+    let lhs = format_lhs(node_name, module, y_pin)?;
+
+    let rhs = match node.op {
+        NodeOp::Const => {
+            let params = node.params.as_ref().and_then(|map| map.get("value"));
+            let value = params.and_then(|value| value.as_str()).ok_or_else(|| {
+                VerilogExportError::MissingPin {
+                    node: node_name.to_string(),
+                    pin: "value".to_string(),
+                }
+            })?;
+            format_const_expr(value, node.width)
+        }
+        NodeOp::Slice | NodeOp::Cat => format_expr(
+            node_name,
+            module,
+            node.pin_map
+                .get("A")
+                .ok_or_else(|| VerilogExportError::MissingPin {
+                    node: node_name.to_string(),
+                    pin: "A".to_string(),
+                })?,
+        )?,
+        NodeOp::Not => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            format!("~({})", a)
+        }
+        NodeOp::And => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            format!("({}) & ({})", a, b)
+        }
+        NodeOp::Or => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            format!("({}) | ({})", a, b)
+        }
+        NodeOp::Xor => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            format!("({}) ^ ({})", a, b)
+        }
+        NodeOp::Xnor => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            format!("({}) ~^ ({})", a, b)
+        }
+        NodeOp::Mux => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            let s = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("S")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "S".to_string(),
+                    })?,
+            )?;
+            format!("({}) ? ({}) : ({})", s, b, a)
+        }
+        NodeOp::Add => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            format!("({}) + ({})", a, b)
+        }
+        NodeOp::Sub => {
+            let a = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("A")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "A".to_string(),
+                    })?,
+            )?;
+            let b = format_expr(
+                node_name,
+                module,
+                node.pin_map
+                    .get("B")
+                    .ok_or_else(|| VerilogExportError::MissingPin {
+                        node: node_name.to_string(),
+                        pin: "B".to_string(),
+                    })?,
+            )?;
+            format!("({}) - ({})", a, b)
+        }
+        _ => {
+            return Err(VerilogExportError::UnsupportedOperation {
+                node: node_name.to_string(),
+                op: node.op.clone(),
+            });
+        }
+    };
+
+    Ok(Assignment { lhs, rhs })
+}
+
+fn collect_dff(
+    node_name: &str,
+    node: &Node,
+    module: &Module,
+) -> Result<DffExport, VerilogExportError> {
+    let q_ref = node
+        .pin_map
+        .get("Q")
+        .ok_or_else(|| VerilogExportError::MissingPin {
+            node: node_name.to_string(),
+            pin: "Q".to_string(),
+        })?
+        .clone();
+    let d_ref = node
+        .pin_map
+        .get("D")
+        .ok_or_else(|| VerilogExportError::MissingPin {
+            node: node_name.to_string(),
+            pin: "D".to_string(),
+        })?
+        .clone();
+    let clk_ref = node
+        .pin_map
+        .get("CLK")
+        .ok_or_else(|| VerilogExportError::MissingPin {
+            node: node_name.to_string(),
+            pin: "CLK".to_string(),
+        })?;
+
+    let reg_name = sanitize_identifier(&format!("{}_reg", node.uid));
+    let clk_expr = format_expr(node_name, module, clk_ref)?;
+    let d_expr = format_expr(node_name, module, &d_ref)?;
+
+    Ok(DffExport {
+        reg_name,
+        width: node.width,
+        node_name: node_name.to_string(),
+        q_binding: q_ref,
+        d_expr,
+        clk_expr,
+    })
+}
+
+fn format_expr(node: &str, module: &Module, bitref: &BitRef) -> Result<String, VerilogExportError> {
+    match bitref {
+        BitRef::Net(net) => format_net_ref(node, module, net),
+        BitRef::Const(constant) => Ok(format_const_expr(&constant.value, constant.width)),
+        BitRef::Concat(BitRefConcat { concat }) => {
+            let mut parts = Vec::with_capacity(concat.len());
+            for part in concat {
+                parts.push(format_expr(node, module, part)?);
+            }
+            Ok(format!("{{{}}}", parts.join(", ")))
+        }
+    }
+}
+
+fn format_lhs(node: &str, module: &Module, bitref: &BitRef) -> Result<String, VerilogExportError> {
+    match bitref {
+        BitRef::Const(_) => Err(VerilogExportError::ConstOnOutput {
+            node: node.to_string(),
+            pin: "Y".to_string(),
+        }),
+        BitRef::Net(_) | BitRef::Concat(_) => format_expr(node, module, bitref),
+    }
+}
+
+fn format_net_ref(
+    node: &str,
+    module: &Module,
+    net: &BitRefNet,
+) -> Result<String, VerilogExportError> {
+    let definition = module
+        .nets
+        .get(&net.net)
+        .ok_or_else(|| VerilogExportError::UnknownNet {
+            node: node.to_string(),
+            net: net.net.clone(),
+        })?;
+    if net.lsb == 0 && net.msb + 1 == definition.bits {
+        Ok(net.net.clone())
+    } else if net.lsb == net.msb {
+        Ok(format!("{}[{}]", net.net, net.lsb))
+    } else {
+        Ok(format!("{}[{}:{}]", net.net, net.msb, net.lsb))
+    }
+}
+
+fn format_const_expr(value: &str, width: u32) -> String {
+    let mut cleaned: String = value.chars().filter(|ch| *ch != '_').collect();
+    if cleaned.starts_with("0b") || cleaned.starts_with("0B") {
+        let digits = cleaned.split_off(2);
+        format!("{}'b{}", width, digits)
+    } else if cleaned.starts_with("0x") || cleaned.starts_with("0X") {
+        let digits = cleaned.split_off(2);
+        format!("{}'h{}", width, digits)
+    } else if cleaned.starts_with("0o") || cleaned.starts_with("0O") {
+        let digits = cleaned.split_off(2);
+        format!("{}'o{}", width, digits)
+    } else {
+        if cleaned.starts_with('+') {
+            cleaned.remove(0);
+        }
+        format!("{}'d{}", width, cleaned)
+    }
+}
+
+fn format_width(width: u32) -> String {
+    if width <= 1 {
+        String::new()
+    } else {
+        format!("[{}:0] ", width - 1)
+    }
+}
+
+fn sanitize_identifier(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            result.push(ch);
+        } else {
+            result.push('_');
+        }
+    }
+    if result.is_empty() || result.chars().next().unwrap().is_ascii_digit() {
+        result.insert(0, '_');
+    }
+    result
+}

--- a/v2m/core/nir/tests/yosys_equivalence.rs
+++ b/v2m/core/nir/tests/yosys_equivalence.rs
@@ -1,0 +1,954 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+use v2m_formats::nir::{
+    BitRef, BitRefConcat, BitRefConst, BitRefNet, Module, Net, Nir, Node, NodeOp, Port,
+    PortDirection,
+};
+use v2m_nir::nir_to_verilog;
+
+const FA8_SPEC: &str = r#"module fa8_spec(
+    input wire [7:0] a,
+    input wire [7:0] b,
+    input wire cin,
+    output wire [7:0] sum,
+    output wire cout
+);
+    wire [8:0] total;
+    assign total = {1'b0, a} + {b, cin};
+    assign sum = total[7:0];
+    assign cout = total[8];
+endmodule
+"#;
+
+const ALU32_SPEC: &str = r#"module alu32_spec(
+    input wire [31:0] a,
+    input wire [31:0] b,
+    input wire [1:0] op,
+    output wire [31:0] y
+);
+    wire [31:0] sum = a + b;
+    wire [31:0] and_ab = a & b;
+    wire [31:0] or_ab = a | b;
+    wire [31:0] xor_ab = a ^ b;
+    wire [31:0] lo_sel = op[0] ? and_ab : sum;
+    wire [31:0] hi_sel = op[0] ? xor_ab : or_ab;
+    assign y = op[1] ? hi_sel : lo_sel;
+endmodule
+"#;
+
+const COUNTER_SPEC: &str = r#"module counter4_spec(
+    input wire clk,
+    input wire rst,
+    output reg [3:0] count
+);
+    always @(posedge clk) begin
+        if (rst) begin
+            count <= 4'd0;
+        end else begin
+            count <= count + 4'd1;
+        end
+    end
+endmodule
+"#;
+
+const FIFO_SPEC: &str = r#"module fifo_small_spec(
+    input wire clk,
+    input wire rst,
+    input wire enq_valid,
+    output wire enq_ready,
+    input wire [7:0] enq_data,
+    input wire deq_ready,
+    output wire deq_valid,
+    output wire [7:0] deq_data
+);
+    reg valid;
+    reg [7:0] data;
+
+    assign enq_ready = ~valid | deq_ready;
+    assign deq_valid = valid;
+    assign deq_data = data;
+
+    wire hold_valid = valid & ~deq_ready;
+    wire enq_fire = enq_valid & enq_ready;
+    wire next_valid = hold_valid | enq_fire;
+    wire [7:0] data_after_enq = enq_fire ? enq_data : data;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            valid <= 1'b0;
+            data <= 8'h00;
+        end else begin
+            valid <= next_valid;
+            data <= data_after_enq;
+        end
+    end
+endmodule
+"#;
+
+#[test]
+fn yosys_equivalence_fa8() {
+    let design = build_fa8_nir();
+    check_comb_equivalence(&design, FA8_SPEC, "fa8_spec");
+}
+
+#[test]
+fn yosys_equivalence_alu32() {
+    let design = build_alu32_nir();
+    check_comb_equivalence(&design, ALU32_SPEC, "alu32_spec");
+}
+
+#[test]
+fn yosys_equivalence_counter() {
+    let design = build_counter_nir();
+    check_sequential_equivalence(&design, COUNTER_SPEC, "counter4_spec", 8);
+}
+
+#[test]
+fn yosys_equivalence_fifo() {
+    let design = build_fifo_nir();
+    check_sequential_equivalence(&design, FIFO_SPEC, "fifo_small_spec", 8);
+}
+
+fn check_comb_equivalence(design: &Nir, spec: &str, spec_top: &str) {
+    let dir = tempdir().expect("create tempdir");
+    let dut_path = write_temp(
+        dir.path(),
+        "dut.v",
+        &nir_to_verilog(design).expect("export verilog"),
+    );
+    let spec_path = write_temp(dir.path(), "spec.v", spec);
+    let script_path = write_temp(
+        dir.path(),
+        "check.ys",
+        &comb_script(&spec_path, spec_top, &dut_path, design.top.as_str()),
+    );
+    run_yosys(&script_path);
+}
+
+fn check_sequential_equivalence(design: &Nir, spec: &str, spec_top: &str, cycles: u32) {
+    let dir = tempdir().expect("create tempdir");
+    let dut_path = write_temp(
+        dir.path(),
+        "dut.v",
+        &nir_to_verilog(design).expect("export verilog"),
+    );
+    let spec_path = write_temp(dir.path(), "spec.v", spec);
+    let script_path = write_temp(
+        dir.path(),
+        "check.ys",
+        &seq_script(&spec_path, spec_top, &dut_path, design.top.as_str(), cycles),
+    );
+    run_yosys(&script_path);
+}
+
+fn run_yosys(script: &Path) {
+    let output = Command::new("yosys")
+        .arg("-q")
+        .arg("-s")
+        .arg(script)
+        .output()
+        .expect("invoke yosys");
+    if !output.status.success() {
+        panic!(
+            "yosys failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn comb_script(spec: &Path, spec_top: &str, dut: &Path, dut_top: &str) -> String {
+    format!(
+        "read_verilog \"{}\"\n\
+         prep -top {}\n\
+         rename {} spec\n\
+         design -stash gold\n\
+         design -reset\n\
+         read_verilog \"{}\"\n\
+         prep -top {}\n\
+         rename {} dut\n\
+         design -stash gate\n\
+         design -reset\n\
+         design -copy-from gold spec spec\n\
+         design -copy-from gate dut dut\n\
+         equiv_make spec dut equiv\n\
+         hierarchy -top equiv\n\
+         equiv_simple\n\
+         equiv_status -assert\n",
+        spec.display(),
+        spec_top,
+        spec_top,
+        dut.display(),
+        dut_top,
+        dut_top
+    )
+}
+
+fn seq_script(spec: &Path, spec_top: &str, dut: &Path, dut_top: &str, cycles: u32) -> String {
+    format!(
+        "read_verilog \"{}\"\n\
+         prep -top {}\n\
+         rename {} spec\n\
+         design -stash gold\n\
+         design -reset\n\
+         read_verilog \"{}\"\n\
+         prep -top {}\n\
+         rename {} dut\n\
+         design -stash gate\n\
+         design -reset\n\
+         design -copy-from gold spec spec\n\
+         design -copy-from gate dut dut\n\
+         miter -equiv -flatten spec dut miter\n\
+         hierarchy -top miter\n\
+         setundef -zero -params\n\
+         sat -verify -seq {} -set-init-zero -prove trigger 0\n",
+        spec.display(),
+        spec_top,
+        spec_top,
+        dut.display(),
+        dut_top,
+        dut_top,
+        cycles
+    )
+}
+
+fn write_temp(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write temp file");
+    path
+}
+
+fn build_fa8_nir() -> Nir {
+    let mut ports = BTreeMap::new();
+    ports.insert(
+        "a".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 8,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "b".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 8,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "cin".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "sum".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 8,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "cout".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 1,
+            attrs: None,
+        },
+    );
+
+    let mut nets = BTreeMap::new();
+    nets.insert(
+        "a".into(),
+        Net {
+            bits: 8,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "b".into(),
+        Net {
+            bits: 8,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "cin".into(),
+        Net {
+            bits: 1,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "sum".into(),
+        Net {
+            bits: 8,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "cout".into(),
+        Net {
+            bits: 1,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "sum_ext".into(),
+        Net {
+            bits: 9,
+            attrs: None,
+        },
+    );
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        "adder".into(),
+        node(
+            "adder",
+            NodeOp::Add,
+            9,
+            BTreeMap::from([
+                ("A".into(), concat(vec![const_bits("0", 1), net("a", 0, 7)])),
+                ("B".into(), concat(vec![net("b", 0, 7), net("cin", 0, 0)])),
+                ("Y".into(), net("sum_ext", 0, 8)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "sum_slice".into(),
+        node(
+            "sum_slice",
+            NodeOp::Slice,
+            8,
+            BTreeMap::from([
+                ("A".into(), net("sum_ext", 0, 7)),
+                ("Y".into(), net("sum", 0, 7)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "cout_slice".into(),
+        node(
+            "cout_slice",
+            NodeOp::Slice,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("sum_ext", 8, 8)),
+                ("Y".into(), net("cout", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+
+    make_nir("fa8", Module { ports, nets, nodes })
+}
+
+fn build_alu32_nir() -> Nir {
+    let mut ports = BTreeMap::new();
+    ports.insert(
+        "a".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 32,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "b".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 32,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "op".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 2,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "y".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 32,
+            attrs: None,
+        },
+    );
+
+    let mut nets = BTreeMap::new();
+    for (name, bits) in [
+        ("a", 32),
+        ("b", 32),
+        ("op", 2),
+        ("y", 32),
+        ("sum", 32),
+        ("and_ab", 32),
+        ("or_ab", 32),
+        ("xor_ab", 32),
+        ("lo_sel", 32),
+        ("hi_sel", 32),
+    ] {
+        nets.insert(name.into(), Net { bits, attrs: None });
+    }
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        "add_sum".into(),
+        node(
+            "add_sum",
+            NodeOp::Add,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("a", 0, 31)),
+                ("B".into(), net("b", 0, 31)),
+                ("Y".into(), net("sum", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "and".into(),
+        node(
+            "and",
+            NodeOp::And,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("a", 0, 31)),
+                ("B".into(), net("b", 0, 31)),
+                ("Y".into(), net("and_ab", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "or".into(),
+        node(
+            "or",
+            NodeOp::Or,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("a", 0, 31)),
+                ("B".into(), net("b", 0, 31)),
+                ("Y".into(), net("or_ab", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "xor".into(),
+        node(
+            "xor",
+            NodeOp::Xor,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("a", 0, 31)),
+                ("B".into(), net("b", 0, 31)),
+                ("Y".into(), net("xor_ab", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "mux_lo".into(),
+        node(
+            "mux_lo",
+            NodeOp::Mux,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("sum", 0, 31)),
+                ("B".into(), net("and_ab", 0, 31)),
+                ("S".into(), concat(vec![net("op", 0, 0)])),
+                ("Y".into(), net("lo_sel", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "mux_hi".into(),
+        node(
+            "mux_hi",
+            NodeOp::Mux,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("or_ab", 0, 31)),
+                ("B".into(), net("xor_ab", 0, 31)),
+                ("S".into(), concat(vec![net("op", 0, 0)])),
+                ("Y".into(), net("hi_sel", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "mux_final".into(),
+        node(
+            "mux_final",
+            NodeOp::Mux,
+            32,
+            BTreeMap::from([
+                ("A".into(), net("lo_sel", 0, 31)),
+                ("B".into(), net("hi_sel", 0, 31)),
+                ("S".into(), concat(vec![net("op", 1, 1)])),
+                ("Y".into(), net("y", 0, 31)),
+            ]),
+            None,
+        ),
+    );
+
+    make_nir("alu32", Module { ports, nets, nodes })
+}
+
+fn build_counter_nir() -> Nir {
+    let mut ports = BTreeMap::new();
+    ports.insert(
+        "clk".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "rst".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "count".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 4,
+            attrs: None,
+        },
+    );
+
+    let mut nets = BTreeMap::new();
+    nets.insert(
+        "clk".into(),
+        Net {
+            bits: 1,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "rst".into(),
+        Net {
+            bits: 1,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "count".into(),
+        Net {
+            bits: 4,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "inc".into(),
+        Net {
+            bits: 4,
+            attrs: None,
+        },
+    );
+    nets.insert(
+        "next".into(),
+        Net {
+            bits: 4,
+            attrs: None,
+        },
+    );
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        "add".into(),
+        node(
+            "add",
+            NodeOp::Add,
+            4,
+            BTreeMap::from([
+                ("A".into(), net("count", 0, 3)),
+                ("B".into(), const_bits("1", 4)),
+                ("Y".into(), net("inc", 0, 3)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "mux".into(),
+        node(
+            "mux",
+            NodeOp::Mux,
+            4,
+            BTreeMap::from([
+                ("A".into(), net("inc", 0, 3)),
+                ("B".into(), const_bits("0", 4)),
+                ("S".into(), net("rst", 0, 0)),
+                ("Y".into(), net("next", 0, 3)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "reg".into(),
+        node(
+            "reg",
+            NodeOp::Dff,
+            4,
+            BTreeMap::from([
+                ("D".into(), net("next", 0, 3)),
+                ("Q".into(), net("count", 0, 3)),
+                ("CLK".into(), net("clk", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+
+    make_nir("counter4", Module { ports, nets, nodes })
+}
+
+fn build_fifo_nir() -> Nir {
+    let mut ports = BTreeMap::new();
+    ports.insert(
+        "clk".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "rst".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "enq_valid".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "enq_ready".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "enq_data".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 8,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "deq_ready".into(),
+        Port {
+            dir: PortDirection::Input,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "deq_valid".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 1,
+            attrs: None,
+        },
+    );
+    ports.insert(
+        "deq_data".into(),
+        Port {
+            dir: PortDirection::Output,
+            bits: 8,
+            attrs: None,
+        },
+    );
+
+    let mut nets = BTreeMap::new();
+    for (name, bits) in [
+        ("clk", 1),
+        ("rst", 1),
+        ("enq_valid", 1),
+        ("enq_ready", 1),
+        ("enq_data", 8),
+        ("deq_ready", 1),
+        ("deq_valid", 1),
+        ("deq_data", 8),
+        ("valid_q", 1),
+        ("valid_next", 1),
+        ("valid_next_pre", 1),
+        ("not_valid", 1),
+        ("not_deq_ready", 1),
+        ("hold_valid", 1),
+        ("enq_fire", 1),
+        ("data_q", 8),
+        ("data_after_enq", 8),
+        ("data_next", 8),
+    ] {
+        nets.insert(name.into(), Net { bits, attrs: None });
+    }
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        "valid_reg".into(),
+        node(
+            "valid_reg",
+            NodeOp::Dff,
+            1,
+            BTreeMap::from([
+                ("D".into(), net("valid_next", 0, 0)),
+                ("Q".into(), net("valid_q", 0, 0)),
+                ("CLK".into(), net("clk", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "data_reg".into(),
+        node(
+            "data_reg",
+            NodeOp::Dff,
+            8,
+            BTreeMap::from([
+                ("D".into(), net("data_next", 0, 7)),
+                ("Q".into(), net("data_q", 0, 7)),
+                ("CLK".into(), net("clk", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "not_valid".into(),
+        node(
+            "not_valid",
+            NodeOp::Not,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("valid_q", 0, 0)),
+                ("Y".into(), net("not_valid", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "enq_ready_logic".into(),
+        node(
+            "enq_ready_logic",
+            NodeOp::Or,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("not_valid", 0, 0)),
+                ("B".into(), net("deq_ready", 0, 0)),
+                ("Y".into(), net("enq_ready", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "not_deq_ready".into(),
+        node(
+            "not_deq_ready",
+            NodeOp::Not,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("deq_ready", 0, 0)),
+                ("Y".into(), net("not_deq_ready", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "hold_valid".into(),
+        node(
+            "hold_valid",
+            NodeOp::And,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("valid_q", 0, 0)),
+                ("B".into(), net("not_deq_ready", 0, 0)),
+                ("Y".into(), net("hold_valid", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "enq_fire".into(),
+        node(
+            "enq_fire",
+            NodeOp::And,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("enq_valid", 0, 0)),
+                ("B".into(), net("enq_ready", 0, 0)),
+                ("Y".into(), net("enq_fire", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "valid_next_pre".into(),
+        node(
+            "valid_next_pre",
+            NodeOp::Or,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("hold_valid", 0, 0)),
+                ("B".into(), net("enq_fire", 0, 0)),
+                ("Y".into(), net("valid_next_pre", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "valid_next".into(),
+        node(
+            "valid_next",
+            NodeOp::Mux,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("valid_next_pre", 0, 0)),
+                ("B".into(), const_bits("0", 1)),
+                ("S".into(), net("rst", 0, 0)),
+                ("Y".into(), net("valid_next", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "data_after_enq".into(),
+        node(
+            "data_after_enq",
+            NodeOp::Mux,
+            8,
+            BTreeMap::from([
+                ("A".into(), net("data_q", 0, 7)),
+                ("B".into(), net("enq_data", 0, 7)),
+                ("S".into(), net("enq_fire", 0, 0)),
+                ("Y".into(), net("data_after_enq", 0, 7)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "data_next".into(),
+        node(
+            "data_next",
+            NodeOp::Mux,
+            8,
+            BTreeMap::from([
+                ("A".into(), net("data_after_enq", 0, 7)),
+                ("B".into(), const_bits("0", 8)),
+                ("S".into(), net("rst", 0, 0)),
+                ("Y".into(), net("data_next", 0, 7)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "deq_valid_out".into(),
+        node(
+            "deq_valid_out",
+            NodeOp::Slice,
+            1,
+            BTreeMap::from([
+                ("A".into(), net("valid_q", 0, 0)),
+                ("Y".into(), net("deq_valid", 0, 0)),
+            ]),
+            None,
+        ),
+    );
+    nodes.insert(
+        "deq_data_out".into(),
+        node(
+            "deq_data_out",
+            NodeOp::Slice,
+            8,
+            BTreeMap::from([
+                ("A".into(), net("data_q", 0, 7)),
+                ("Y".into(), net("deq_data", 0, 7)),
+            ]),
+            None,
+        ),
+    );
+
+    make_nir("fifo_small", Module { ports, nets, nodes })
+}
+
+fn node(
+    uid: &str,
+    op: NodeOp,
+    width: u32,
+    pin_map: BTreeMap<String, BitRef>,
+    params: Option<BTreeMap<String, Value>>,
+) -> Node {
+    Node {
+        uid: uid.to_string(),
+        op,
+        width,
+        pin_map,
+        params,
+        attrs: None,
+    }
+}
+
+fn net(name: &str, lsb: u32, msb: u32) -> BitRef {
+    BitRef::Net(BitRefNet {
+        net: name.to_string(),
+        lsb,
+        msb,
+    })
+}
+
+fn const_bits(value: &str, width: u32) -> BitRef {
+    BitRef::Const(BitRefConst {
+        value: value.to_string(),
+        width,
+    })
+}
+
+fn concat(parts: Vec<BitRef>) -> BitRef {
+    BitRef::Concat(BitRefConcat { concat: parts })
+}
+
+fn make_nir(design_name: &str, module: Module) -> Nir {
+    let mut modules = BTreeMap::new();
+    modules.insert(design_name.to_string(), module);
+    Nir {
+        v: "nir-1.1".to_string(),
+        design: design_name.to_string(),
+        top: design_name.to_string(),
+        attrs: None,
+        modules,
+        generator: None,
+        cmdline: None,
+        source_digest_sha256: None,
+    }
+}


### PR DESCRIPTION
## Summary
- add a `nir_to_verilog` exporter and supporting error type to emit Verilog for NIR modules
- introduce Yosys-based equivalence tests covering fa8, alu32, counter, and fifo sample designs
- pull in the tempfile dev-dependency to manage temporary files during equivalence checks

## Testing
- cargo test -p v2m-nir

------
https://chatgpt.com/codex/tasks/task_e_68cb02614fe083239689edd707e69299