### PR TITLE
Refactor NIR bit resolution to use net IDs

### DIFF
--- a/v2m/core/formats/src/lib.rs
+++ b/v2m/core/formats/src/lib.rs
@@ -12,7 +12,10 @@ pub mod tir;
 pub mod wir;
 
 pub use constraints::Constraints;
-pub use nir::{load_nir, resolve_bitref, save_nir, BitRef, Nir, ResolvedBit, ResolvedNetBit};
+pub use nir::{
+    load_nir, resolve_bitref, resolve_bitref_net_ids, save_nir, BitRef, Nir, ResolvedBit,
+    ResolvedBitId, ResolvedNetBit,
+};
 pub use pir::Pir;
 pub use techlib::Techlib;
 pub use tir::Tir;

--- a/v2m/core/nir/src/lib.rs
+++ b/v2m/core/nir/src/lib.rs
@@ -17,7 +17,7 @@ pub use strash::{Literal, ParamMap, StrashKind, StrashNode, StrashNodeId, Struct
 pub use verilog::{nir_to_verilog, VerilogExportError};
 
 use v2m_formats::nir::{Module, NodeOp};
-use v2m_formats::{resolve_bitref, BitRef, ResolvedBit};
+use v2m_formats::{resolve_bitref_net_ids, BitRef, ResolvedBitId};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NetId(usize);
@@ -47,12 +47,6 @@ pub enum BuildError {
         pin: String,
         #[source]
         source: v2m_formats::Error,
-    },
-    #[error("net `{net}` referenced by pin `{pin}` on node `{node}` not found")]
-    UnknownNet {
-        node: String,
-        pin: String,
-        net: String,
     },
 }
 
@@ -329,6 +323,10 @@ impl ModuleGraph {
         self.net_lookup.get(name).copied()
     }
 
+    pub fn net_lookup(&self) -> &HashMap<String, NetId> {
+        &self.net_lookup
+    }
+
     pub fn node_id(&self, name: &str) -> Option<NodeId> {
         self.node_lookup.get(name).copied()
     }
@@ -549,26 +547,17 @@ fn collect_pin_nets(
     node_name: &str,
     pin_name: &str,
 ) -> Result<Vec<NetId>, BuildError> {
-    let resolved = resolve_bitref(module, bitref).map_err(|source| BuildError::PinResolve {
-        node: node_name.to_string(),
-        pin: pin_name.to_string(),
-        source,
+    let resolved = resolve_bitref_net_ids(module, bitref, net_lookup).map_err(|source| {
+        BuildError::PinResolve {
+            node: node_name.to_string(),
+            pin: pin_name.to_string(),
+            source,
+        }
     })?;
 
     let mut nets = BTreeSet::new();
     for resolved_bit in resolved {
-        if let ResolvedBit::Net(bit) = resolved_bit {
-            let net_name = bit.net;
-            let net_id = match net_lookup.get(net_name.as_str()) {
-                Some(id) => *id,
-                None => {
-                    return Err(BuildError::UnknownNet {
-                        node: node_name.to_string(),
-                        pin: pin_name.to_string(),
-                        net: net_name,
-                    })
-                }
-            };
+        if let ResolvedBitId::Net((net_id, _)) = resolved_bit {
             nets.insert(net_id);
         }
     }


### PR DESCRIPTION
## Summary
- add a resolve_bitref_net_ids helper that resolves bitrefs against a provided net lookup without cloning net names
- refactor the normalization path to track net state by NetId, rework register snapshots, and reuse the helper for pin resolution
- update collect_pin_nets and the format tests to exercise the new typed resolution flow

## Testing
- cargo test --manifest-path v2m/Cargo.toml -p v2m-nir --test pipeline_eval
- cargo test --manifest-path v2m/Cargo.toml -p v2m-nir --test nir_golden

------
https://chatgpt.com/codex/tasks/task_e_68cb3e51c514832393c52e6ab3dbdedc