### PR TITLE
Add Yosys RTLIL JSON loader with validation

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -1881,6 +1881,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yosys-bridge"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/v2m/Cargo.toml
+++ b/v2m/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "core/nir",
     "evaluator",
     "cli",
-    "crates/tools-yosys"
+    "crates/tools-yosys",
+    "crates/yosys-bridge"
 ]
 resolver = "2"
 

--- a/v2m/crates/yosys-bridge/Cargo.toml
+++ b/v2m/crates/yosys-bridge/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "yosys-bridge"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/v2m/crates/yosys-bridge/src/lib.rs
+++ b/v2m/crates/yosys-bridge/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod loader;
+
+pub use loader::{load_rtlil_json, LoaderOptions, Module, RtlilJson};

--- a/v2m/crates/yosys-bridge/src/loader.rs
+++ b/v2m/crates/yosys-bridge/src/loader.rs
@@ -1,0 +1,172 @@
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use serde::Deserialize;
+use serde_json::Value;
+use std::{collections::BTreeMap, fs, path::Path};
+
+#[derive(Debug, Default, Clone)]
+pub struct LoaderOptions {
+    pub allow_mem_blackbox: bool,
+}
+
+#[derive(Debug)]
+pub struct RtlilJson {
+    pub top: String,
+    pub modules: BTreeMap<String, Module>,
+}
+
+#[derive(Debug)]
+pub struct Module {
+    pub attributes: BTreeMap<String, Value>,
+    pub ports: BTreeMap<String, Value>,
+    pub cells: BTreeMap<String, Cell>,
+    pub netnames: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Cell {
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRtlilJson {
+    modules: Option<BTreeMap<String, RawModule>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawModule {
+    #[serde(default)]
+    attributes: BTreeMap<String, Value>,
+    ports: Option<BTreeMap<String, Value>>,
+    cells: Option<BTreeMap<String, Cell>>,
+    netnames: Option<BTreeMap<String, Value>>,
+}
+
+impl Module {
+    fn from_raw(name: &str, raw: RawModule) -> Result<Self> {
+        let ports = raw
+            .ports
+            .ok_or_else(|| anyhow!("RTLIL module `{}` is missing `ports`", name))?;
+        let cells = raw
+            .cells
+            .ok_or_else(|| anyhow!("RTLIL module `{}` is missing `cells`", name))?;
+        let netnames = raw
+            .netnames
+            .ok_or_else(|| anyhow!("RTLIL module `{}` is missing `netnames`", name))?;
+
+        Ok(Self {
+            attributes: raw.attributes,
+            ports,
+            cells,
+            netnames,
+        })
+    }
+
+    fn is_top(&self) -> bool {
+        const TOP_KEYS: [&str; 2] = ["top", "\\top"];
+        self.attributes
+            .iter()
+            .filter(|(key, _)| TOP_KEYS.contains(&key.as_str()))
+            .any(|(_, value)| value_is_truthy(value))
+    }
+}
+
+pub fn load_rtlil_json(path: impl AsRef<Path>, options: &LoaderOptions) -> Result<RtlilJson> {
+    let path = path.as_ref();
+    let raw_data = fs::read_to_string(path)
+        .with_context(|| format!("failed to read RTLIL JSON from {}", display_path(path)))?;
+
+    let raw: RawRtlilJson = serde_json::from_str(&raw_data)
+        .with_context(|| format!("failed to parse RTLIL JSON from {}", display_path(path)))?;
+
+    let modules_map = raw
+        .modules
+        .ok_or_else(|| anyhow!("RTLIL JSON is missing the `modules` map"))?;
+    ensure!(
+        !modules_map.is_empty(),
+        "RTLIL JSON does not contain any modules"
+    );
+
+    let mut modules = BTreeMap::new();
+    let mut top_modules = Vec::new();
+    let mut memory_cells = Vec::new();
+
+    for (name, raw_module) in modules_map {
+        let module = Module::from_raw(&name, raw_module)?;
+
+        if module.is_top() {
+            top_modules.push(name.clone());
+        }
+
+        for (cell_name, cell) in &module.cells {
+            if is_memory_cell(&cell.kind) {
+                memory_cells.push(format!("{name}.{cell_name}"));
+            }
+        }
+
+        modules.insert(name, module);
+    }
+
+    let top = match top_modules.len() {
+        0 => {
+            bail!(
+                "RTLIL JSON does not identify a top module. Add the `(* top *)` attribute before exporting."
+            )
+        }
+        1 => top_modules.remove(0),
+        _ => bail!(
+            "multiple RTLIL modules are marked as top: {}",
+            top_modules.join(", ")
+        ),
+    };
+
+    if !memory_cells.is_empty() && !options.allow_mem_blackbox {
+        bail!(
+            "RTLIL JSON still contains memory cells that must be lowered: {}",
+            memory_cells.join(", ")
+        );
+    }
+
+    Ok(RtlilJson { top, modules })
+}
+
+fn is_memory_cell(cell_type: &str) -> bool {
+    matches!(cell_type, "$mem" | "$memrd" | "$memwr")
+}
+
+fn value_is_truthy(value: &Value) -> bool {
+    match value {
+        Value::Bool(true) => true,
+        Value::Number(num) => num.as_u64() == Some(1),
+        Value::String(s) => s == "1" || s.eq_ignore_ascii_case("true"),
+        _ => false,
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truthy_attribute_variants() {
+        assert!(value_is_truthy(&Value::Bool(true)));
+        assert!(value_is_truthy(&Value::String("1".to_string())));
+        assert!(value_is_truthy(&Value::String("TRUE".to_string())));
+        assert!(value_is_truthy(&serde_json::json!(1)));
+        assert!(!value_is_truthy(&Value::Bool(false)));
+        assert!(!value_is_truthy(&serde_json::json!(0)));
+        assert!(!value_is_truthy(&Value::String("no".to_string())));
+    }
+
+    #[test]
+    fn memory_cell_detection() {
+        assert!(is_memory_cell("$mem"));
+        assert!(is_memory_cell("$memrd"));
+        assert!(is_memory_cell("$memwr"));
+        assert!(!is_memory_cell("$dff"));
+    }
+}

--- a/v2m/crates/yosys-bridge/tests/fixtures/full_adder.json
+++ b/v2m/crates/yosys-bridge/tests/fixtures/full_adder.json
@@ -1,0 +1,79 @@
+{
+  "modules": {
+    "full_adder": {
+      "attributes": {
+        "top": 1,
+        "src": "full_adder.v:1"
+      },
+      "ports": {
+        "a": { "direction": "input", "bits": [1] },
+        "b": { "direction": "input", "bits": [2] },
+        "cin": { "direction": "input", "bits": [3] },
+        "sum": { "direction": "output", "bits": [4] },
+        "cout": { "direction": "output", "bits": [5] }
+      },
+      "cells": {
+        "xor0": {
+          "type": "$xor",
+          "parameters": {},
+          "attributes": {},
+          "connections": {
+            "A": [1],
+            "B": [2],
+            "Y": [6]
+          }
+        },
+        "xor1": {
+          "type": "$xor",
+          "parameters": {},
+          "attributes": {},
+          "connections": {
+            "A": [6],
+            "B": [3],
+            "Y": [4]
+          }
+        },
+        "and0": {
+          "type": "$and",
+          "parameters": {},
+          "attributes": {},
+          "connections": {
+            "A": [1],
+            "B": [2],
+            "Y": [7]
+          }
+        },
+        "and1": {
+          "type": "$and",
+          "parameters": {},
+          "attributes": {},
+          "connections": {
+            "A": [6],
+            "B": [3],
+            "Y": [8]
+          }
+        },
+        "or0": {
+          "type": "$or",
+          "parameters": {},
+          "attributes": {},
+          "connections": {
+            "A": [7],
+            "B": [8],
+            "Y": [5]
+          }
+        }
+      },
+      "netnames": {
+        "a": { "bits": [1], "attributes": {} },
+        "b": { "bits": [2], "attributes": {} },
+        "cin": { "bits": [3], "attributes": {} },
+        "sum": { "bits": [4], "attributes": {} },
+        "cout": { "bits": [5], "attributes": {} },
+        "$auto$wire$0": { "bits": [6], "attributes": {} },
+        "$auto$wire$1": { "bits": [7], "attributes": {} },
+        "$auto$wire$2": { "bits": [8], "attributes": {} }
+      }
+    }
+  }
+}

--- a/v2m/crates/yosys-bridge/tests/fixtures/has_mem.json
+++ b/v2m/crates/yosys-bridge/tests/fixtures/has_mem.json
@@ -1,0 +1,31 @@
+{
+  "modules": {
+    "memory_block": {
+      "attributes": {
+        "top": 1
+      },
+      "ports": {
+        "clk": { "direction": "input", "bits": [1] },
+        "data_in": { "direction": "input", "bits": [2, 3, 4, 5] },
+        "data_out": { "direction": "output", "bits": [6, 7, 8, 9] }
+      },
+      "cells": {
+        "mem_inst": {
+          "type": "$mem",
+          "attributes": {},
+          "parameters": {},
+          "connections": {
+            "CLK": [1],
+            "DATA": [2, 3, 4, 5],
+            "OUT": [6, 7, 8, 9]
+          }
+        }
+      },
+      "netnames": {
+        "clk": { "bits": [1], "attributes": {} },
+        "data_in": { "bits": [2, 3, 4, 5], "attributes": {} },
+        "data_out": { "bits": [6, 7, 8, 9], "attributes": {} }
+      }
+    }
+  }
+}

--- a/v2m/crates/yosys-bridge/tests/fixtures/missing_top.json
+++ b/v2m/crates/yosys-bridge/tests/fixtures/missing_top.json
@@ -1,0 +1,12 @@
+{
+  "modules": {
+    "helper": {
+      "attributes": {
+        "src": "helper.v:1"
+      },
+      "ports": {},
+      "cells": {},
+      "netnames": {}
+    }
+  }
+}

--- a/v2m/crates/yosys-bridge/tests/loader.rs
+++ b/v2m/crates/yosys-bridge/tests/loader.rs
@@ -1,0 +1,64 @@
+use std::{fs, path::PathBuf};
+
+use yosys_bridge::{load_rtlil_json, LoaderOptions};
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+#[test]
+fn loads_full_adder_fixture() {
+    let rtlil = load_rtlil_json(fixture_path("full_adder.json"), &LoaderOptions::default())
+        .expect("load full_adder.json");
+
+    assert_eq!(rtlil.top, "full_adder");
+    assert!(rtlil.modules.contains_key("full_adder"));
+}
+
+#[test]
+fn errors_when_modules_missing() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("missing_modules.json");
+    fs::write(&path, "{\"creator\": \"yosys\"}").expect("write temp json");
+
+    let error = load_rtlil_json(&path, &LoaderOptions::default()).expect_err("expect error");
+    assert!(
+        error.to_string().contains("modules"),
+        "error did not mention missing modules: {error:?}"
+    );
+}
+
+#[test]
+fn detects_remaining_memory_cells() {
+    let error = load_rtlil_json(fixture_path("has_mem.json"), &LoaderOptions::default())
+        .expect_err("expect error when memory cells remain");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("mem_inst"),
+        "error missing cell name: {message}"
+    );
+}
+
+#[test]
+fn allow_mem_blackbox_bypasses_memory_check() {
+    let mut options = LoaderOptions::default();
+    options.allow_mem_blackbox = true;
+
+    let rtlil = load_rtlil_json(fixture_path("has_mem.json"), &options)
+        .expect("allow_mem_blackbox should permit memory cells");
+    assert_eq!(rtlil.top, "memory_block");
+}
+
+#[test]
+fn errors_when_top_module_missing() {
+    let error = load_rtlil_json(fixture_path("missing_top.json"), &LoaderOptions::default())
+        .expect_err("expect top module error");
+
+    assert!(
+        error.to_string().to_lowercase().contains("top"),
+        "error should mention top module"
+    );
+}


### PR DESCRIPTION
## Summary
- add a `yosys-bridge` crate that can read RTLIL JSON through serde
- validate that modules expose required sections, a top module, and report unmapped memories
- add fixtures and tests covering successful loads and the new validation errors

## Testing
- cargo test -p yosys-bridge

------
https://chatgpt.com/codex/tasks/task_e_68cc4f5d3d948323b5f76f84a11732d9