### PR TITLE
Refactor normalizer to use NodeId-based indexing

### DIFF
--- a/v2m/core/formats/src/nir.rs
+++ b/v2m/core/formats/src/nir.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
+use std::hash::BuildHasher;
 use std::path::Path;
 use std::sync::LazyLock;
 
@@ -216,10 +217,10 @@ pub fn resolve_bitref(module: &Module, bitref: &BitRef) -> Result<Vec<ResolvedBi
     }
 }
 
-pub fn resolve_bitref_net_ids<Id: Copy>(
+pub fn resolve_bitref_net_ids<Id: Copy, S: BuildHasher>(
     module: &Module,
     bitref: &BitRef,
-    net_lookup: &HashMap<String, Id>,
+    net_lookup: &HashMap<String, Id, S>,
 ) -> Result<Vec<ResolvedBitId<Id>>, Error> {
     match bitref {
         BitRef::Net(net) => resolve_bitref_net_with_ids(module, net, net_lookup),
@@ -270,10 +271,10 @@ fn resolve_bitref_net(module: &Module, net: &BitRefNet) -> Result<Vec<ResolvedBi
     Ok(resolved)
 }
 
-fn resolve_bitref_net_with_ids<Id: Copy>(
+fn resolve_bitref_net_with_ids<Id: Copy, S: BuildHasher>(
     module: &Module,
     net: &BitRefNet,
-    net_lookup: &HashMap<String, Id>,
+    net_lookup: &HashMap<String, Id, S>,
 ) -> Result<Vec<ResolvedBitId<Id>>, Error> {
     let definition = module.nets.get(&net.net).ok_or_else(|| Error::UnknownNet {
         net: net.net.clone(),

--- a/v2m/core/nir/src/lib.rs
+++ b/v2m/core/nir/src/lib.rs
@@ -350,7 +350,7 @@ impl ModuleGraph {
         self.net_lookup.get(name).copied()
     }
 
-    pub fn net_lookup(&self) -> &HashMap<String, NetId> {
+    pub fn net_lookup(&self) -> &FxHashMap<String, NetId> {
         &self.net_lookup
     }
 


### PR DESCRIPTION
## Summary
- update the normalizer to cache module nodes by `NodeId`, eliminate cloning in the combinational evaluator, and propagate typed IDs through helper routines
- track registers by `NodeId`, generating names only for error reporting and final state snapshots
- allow `resolve_bitref_net_ids` to work with hash maps that use arbitrary hash builders so the normalizer can reuse the module graph lookup table

## Testing
- `cargo test -p v2m-nir`


------
https://chatgpt.com/codex/tasks/task_e_68cc5056104c832394ba57dc9bf7202c