### PR TITLE
Implement combinational Yosys cell mapping

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -472,6 +472,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "frontends-yosys-bridge"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "insta",
+ "serde",
+ "serde_json",
+ "v2m-formats",
+ "yosys-bridge",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/v2m/Cargo.toml
+++ b/v2m/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "evaluator",
     "cli",
     "crates/tools-yosys",
-    "crates/yosys-bridge"
+    "crates/yosys-bridge",
+    "frontends/yosys_bridge"
 ]
 resolver = "2"
 

--- a/v2m/crates/yosys-bridge/src/loader.rs
+++ b/v2m/crates/yosys-bridge/src/loader.rs
@@ -26,6 +26,12 @@ pub struct Module {
 pub struct Cell {
     #[serde(rename = "type")]
     pub kind: String,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub attributes: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub connections: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/v2m/frontends/yosys_bridge/Cargo.toml
+++ b/v2m/frontends/yosys_bridge/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "frontends-yosys-bridge"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+yosys-bridge = { path = "../../crates/yosys-bridge" }
+v2m-formats = { path = "../../core/formats" }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/v2m/frontends/yosys_bridge/src/cells/arith.rs
+++ b/v2m/frontends/yosys_bridge/src/cells/arith.rs
@@ -1,0 +1,52 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use serde_json::json;
+use v2m_formats::nir::NodeOp;
+
+use crate::context::Ctx;
+use crate::nir_node::NirNode;
+use yosys_bridge::loader::Cell;
+
+use super::{expect_param_bool, expect_param_u32};
+
+pub fn map_add(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    map_arithmetic(NodeOp::Add, cell, ctx)
+}
+
+pub fn map_sub(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    map_arithmetic(NodeOp::Sub, cell, ctx)
+}
+
+fn map_arithmetic(op: NodeOp, cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    let a = ctx.bitref(cell, "A")?;
+    let b = ctx.bitref(cell, "B")?;
+    let y = ctx.bitref(cell, "Y")?;
+
+    let a_width = expect_param_u32(cell, ctx, "A_WIDTH")?;
+    let b_width = expect_param_u32(cell, ctx, "B_WIDTH")?;
+    let y_width = expect_param_u32(cell, ctx, "Y_WIDTH")?;
+
+    ctx.expect_width("A", &a, a_width)?;
+    ctx.expect_width("B", &b, b_width)?;
+    ctx.expect_width("Y", &y, y_width)?;
+
+    let a_signed = expect_param_bool(cell, ctx, "A_SIGNED")?;
+    let b_signed = expect_param_bool(cell, ctx, "B_SIGNED")?;
+    let y_signed = expect_param_bool(cell, ctx, "Y_SIGNED")?;
+
+    let mut pin_map = BTreeMap::new();
+    pin_map.insert("A".to_string(), a);
+    pin_map.insert("B".to_string(), b);
+    pin_map.insert("Y".to_string(), y);
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert("A_WIDTH".to_string(), json!(a_width));
+    attrs.insert("B_WIDTH".to_string(), json!(b_width));
+    attrs.insert("Y_WIDTH".to_string(), json!(y_width));
+    attrs.insert("A_SIGNED".to_string(), json!(a_signed));
+    attrs.insert("B_SIGNED".to_string(), json!(b_signed));
+    attrs.insert("Y_SIGNED".to_string(), json!(y_signed));
+
+    Ok(NirNode::new(op, y_width, pin_map).with_attrs(attrs))
+}

--- a/v2m/frontends/yosys_bridge/src/cells/logic.rs
+++ b/v2m/frontends/yosys_bridge/src/cells/logic.rs
@@ -1,0 +1,108 @@
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use v2m_formats::nir::NodeOp;
+
+use crate::context::Ctx;
+use crate::nir_node::NirNode;
+use yosys_bridge::loader::Cell;
+
+use super::expect_param_u32;
+
+pub fn map_and(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    map_bitwise_binary(NodeOp::And, cell, ctx)
+}
+
+pub fn map_or(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    map_bitwise_binary(NodeOp::Or, cell, ctx)
+}
+
+pub fn map_xor(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    map_bitwise_binary(NodeOp::Xor, cell, ctx)
+}
+
+pub fn map_xnor(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    map_bitwise_binary(NodeOp::Xnor, cell, ctx)
+}
+
+pub fn map_not(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    let a = ctx.bitref(cell, "A")?;
+    let y = ctx.bitref(cell, "Y")?;
+
+    let a_width = expect_param_u32(cell, ctx, "A_WIDTH")?;
+    let y_width = expect_param_u32(cell, ctx, "Y_WIDTH")?;
+
+    if a_width != y_width {
+        bail!(
+            "cell `{}` in module `{}` has mismatched NOT widths: A_WIDTH={} and Y_WIDTH={}",
+            ctx.cell_name(),
+            ctx.module_name(),
+            a_width,
+            y_width
+        );
+    }
+
+    ctx.expect_width("A", &a, a_width)?;
+    ctx.expect_width("Y", &y, y_width)?;
+
+    let mut pin_map = BTreeMap::new();
+    pin_map.insert("A".to_string(), a);
+    pin_map.insert("Y".to_string(), y);
+
+    Ok(NirNode::new(NodeOp::Not, y_width, pin_map))
+}
+
+pub fn map_mux(cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    let a = ctx.bitref(cell, "A")?;
+    let b = ctx.bitref(cell, "B")?;
+    let s = ctx.bitref(cell, "S")?;
+    let y = ctx.bitref(cell, "Y")?;
+
+    let width = expect_param_u32(cell, ctx, "WIDTH")?;
+    let select_width = expect_param_u32(cell, ctx, "S_WIDTH")?;
+
+    ctx.expect_width("A", &a, width)?;
+    ctx.expect_width("B", &b, width)?;
+    ctx.expect_width("Y", &y, width)?;
+    ctx.expect_width("S", &s, select_width)?;
+
+    let mut pin_map = BTreeMap::new();
+    pin_map.insert("A".to_string(), a);
+    pin_map.insert("B".to_string(), b);
+    pin_map.insert("S".to_string(), s);
+    pin_map.insert("Y".to_string(), y);
+
+    Ok(NirNode::new(NodeOp::Mux, width, pin_map))
+}
+
+fn map_bitwise_binary(op: NodeOp, cell: &Cell, ctx: &mut Ctx) -> Result<NirNode> {
+    let a = ctx.bitref(cell, "A")?;
+    let b = ctx.bitref(cell, "B")?;
+    let y = ctx.bitref(cell, "Y")?;
+
+    let a_width = expect_param_u32(cell, ctx, "A_WIDTH")?;
+    let b_width = expect_param_u32(cell, ctx, "B_WIDTH")?;
+    let y_width = expect_param_u32(cell, ctx, "Y_WIDTH")?;
+
+    if a_width != b_width || a_width != y_width {
+        bail!(
+            "cell `{}` in module `{}` has mismatched widths: A_WIDTH={}, B_WIDTH={}, Y_WIDTH={}",
+            ctx.cell_name(),
+            ctx.module_name(),
+            a_width,
+            b_width,
+            y_width
+        );
+    }
+
+    ctx.expect_width("A", &a, a_width)?;
+    ctx.expect_width("B", &b, b_width)?;
+    ctx.expect_width("Y", &y, y_width)?;
+
+    let mut pin_map = BTreeMap::new();
+    pin_map.insert("A".to_string(), a);
+    pin_map.insert("B".to_string(), b);
+    pin_map.insert("Y".to_string(), y);
+
+    Ok(NirNode::new(op, y_width, pin_map))
+}

--- a/v2m/frontends/yosys_bridge/src/cells/mod.rs
+++ b/v2m/frontends/yosys_bridge/src/cells/mod.rs
@@ -1,0 +1,99 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+
+use crate::context::Ctx;
+use yosys_bridge::loader::Cell;
+
+pub mod arith;
+pub mod logic;
+
+fn expect_param_value<'a>(cell: &'a Cell, ctx: &Ctx, name: &str) -> Result<&'a Value> {
+    cell.parameters.get(name).ok_or_else(|| {
+        anyhow!(
+            "cell `{}` in module `{}` is missing parameter `{}`",
+            ctx.cell_name(),
+            ctx.module_name(),
+            name
+        )
+    })
+}
+
+pub fn expect_param_u32(cell: &Cell, ctx: &Ctx, name: &str) -> Result<u32> {
+    let value = expect_param_value(cell, ctx, name)?;
+    parse_u32(value).with_context(|| parameter_error(ctx, name, "an unsigned integer"))
+}
+
+pub fn expect_param_bool(cell: &Cell, ctx: &Ctx, name: &str) -> Result<bool> {
+    let value = expect_param_value(cell, ctx, name)?;
+    parse_bool(value).with_context(|| parameter_error(ctx, name, "a boolean"))
+}
+
+fn parameter_error(ctx: &Ctx, name: &str, description: &str) -> String {
+    format!(
+        "parameter `{}` on cell `{}` in module `{}` must be {}",
+        name,
+        ctx.cell_name(),
+        ctx.module_name(),
+        description
+    )
+}
+
+fn parse_u32(value: &Value) -> Result<u32> {
+    match value {
+        Value::Number(num) => {
+            if let Some(u) = num.as_u64() {
+                u32::try_from(u).context("numeric parameter value exceeds u32 range")
+            } else if let Some(i) = num.as_i64() {
+                bail!("numeric parameter value `{}` must not be negative", i)
+            } else {
+                bail!("numeric parameter value `{num}` is not an integer")
+            }
+        }
+        Value::String(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                bail!("string parameter value must not be empty");
+            }
+            let parsed: u64 = trimmed
+                .parse()
+                .context("failed to parse numeric string parameter value")?;
+            u32::try_from(parsed).context("string parameter value exceeds u32 range")
+        }
+        other => bail!("unsupported parameter value `{other}`; expected number or string"),
+    }
+}
+
+fn parse_bool(value: &Value) -> Result<bool> {
+    match value {
+        Value::Bool(v) => Ok(*v),
+        Value::Number(num) => {
+            if let Some(u) = num.as_u64() {
+                match u {
+                    0 => Ok(false),
+                    1 => Ok(true),
+                    other => bail!("boolean parameter expected 0 or 1 but found {other}"),
+                }
+            } else if let Some(i) = num.as_i64() {
+                match i {
+                    0 => Ok(false),
+                    1 => Ok(true),
+                    other => bail!("boolean parameter expected 0 or 1 but found {other}"),
+                }
+            } else {
+                bail!("boolean parameter `{num}` is not an integer");
+            }
+        }
+        Value::String(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                bail!("string boolean parameter must not be empty");
+            }
+            match trimmed.to_ascii_lowercase().as_str() {
+                "0" | "false" => Ok(false),
+                "1" | "true" => Ok(true),
+                other => bail!("boolean parameter expected 0/1/true/false but found `{other}`"),
+            }
+        }
+        other => bail!("unsupported parameter value `{other}`; expected boolean"),
+    }
+}

--- a/v2m/frontends/yosys_bridge/src/context.rs
+++ b/v2m/frontends/yosys_bridge/src/context.rs
@@ -1,0 +1,198 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+use v2m_formats::nir::{BitRef, BitRefConcat, BitRefConst, BitRefNet};
+
+type BitLookup = HashMap<i64, NetBitInfo>;
+
+#[derive(Debug, Clone)]
+pub struct NetBitInfo {
+    pub net: String,
+    pub offset: u32,
+}
+
+#[derive(Debug)]
+pub struct Ctx<'a> {
+    module_name: &'a str,
+    cell_name: &'a str,
+    bit_lookup: &'a BitLookup,
+    cache: BTreeMap<String, BitRef>,
+}
+
+impl<'a> Ctx<'a> {
+    pub fn new(module_name: &'a str, cell_name: &'a str, bit_lookup: &'a BitLookup) -> Self {
+        Self {
+            module_name,
+            cell_name,
+            bit_lookup,
+            cache: BTreeMap::new(),
+        }
+    }
+
+    pub fn module_name(&self) -> &str {
+        self.module_name
+    }
+
+    pub fn cell_name(&self) -> &str {
+        self.cell_name
+    }
+
+    pub fn bitref(&mut self, cell: &yosys_bridge::loader::Cell, pin: &str) -> Result<BitRef> {
+        if let Some(bitref) = self.cache.get(pin) {
+            return Ok(bitref.clone());
+        }
+
+        let value = cell
+            .connections
+            .get(pin)
+            .ok_or_else(|| self.missing_pin_error(pin))?;
+
+        let bitref = self.extract_bitref(pin, value).with_context(|| {
+            format!(
+                "failed to extract pin `{pin}` on cell `{}` in module `{}`",
+                self.cell_name, self.module_name
+            )
+        })?;
+        self.cache.insert(pin.to_string(), bitref.clone());
+        Ok(bitref)
+    }
+
+    pub fn bitref_width(bitref: &BitRef) -> u32 {
+        match bitref {
+            BitRef::Net(BitRefNet { lsb, msb, .. }) => msb - lsb + 1,
+            BitRef::Const(BitRefConst { width, .. }) => *width,
+            BitRef::Concat(BitRefConcat { concat }) => concat.iter().map(Self::bitref_width).sum(),
+        }
+    }
+
+    pub fn ensure_equal_width<'b>(&self, entries: &[(&'b str, &'b BitRef)]) -> Result<u32> {
+        let mut width: Option<u32> = None;
+        for (pin, bitref) in entries {
+            let bit_width = Self::bitref_width(bitref);
+            if let Some(current) = width {
+                if current != bit_width {
+                    bail!(
+                        "pin `{}` on cell `{}` in module `{}` has width {} but expected {current}",
+                        pin,
+                        self.cell_name,
+                        self.module_name,
+                        bit_width
+                    );
+                }
+            } else {
+                width = Some(bit_width);
+            }
+        }
+
+        width.ok_or_else(|| {
+            anyhow!(
+                "expected at least one pin to determine width for cell `{}` in module `{}`",
+                self.cell_name,
+                self.module_name
+            )
+        })
+    }
+
+    pub fn expect_width(&self, pin: &str, bitref: &BitRef, expected: u32) -> Result<()> {
+        let actual = Self::bitref_width(bitref);
+        if actual != expected {
+            bail!(
+                "pin `{}` on cell `{}` in module `{}` has width {} but expected {}",
+                pin,
+                self.cell_name,
+                self.module_name,
+                actual,
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    fn extract_bitref(&self, pin: &str, value: &Value) -> Result<BitRef> {
+        let mut bits = Vec::new();
+        self.collect_bits(pin, value, &mut bits)?;
+        let extracted = yosys_bridge::bitref::to_bitref(&bits)?;
+        Ok(convert_bitref(&extracted))
+    }
+
+    fn collect_bits(
+        &self,
+        pin: &str,
+        value: &Value,
+        bits: &mut Vec<yosys_bridge::bitref::RtlilBit>,
+    ) -> Result<()> {
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    self.collect_bits(pin, item, bits)?;
+                }
+                Ok(())
+            }
+            Value::Number(num) => {
+                let bit_id = num
+                    .as_i64()
+                    .ok_or_else(|| anyhow!("connection bit for pin `{pin}` is not an integer"))?;
+                let info = self
+                    .bit_lookup
+                    .get(&bit_id)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "pin `{pin}` on cell `{}` in module `{}` references unknown net bit {}",
+                            self.cell_name, self.module_name, bit_id
+                        )
+                    })?;
+                bits.push(yosys_bridge::bitref::RtlilBit::Net {
+                    net: info.net.clone(),
+                    bit_index: info.offset,
+                });
+                Ok(())
+            }
+            Value::String(text) => {
+                if text.is_empty() {
+                    bail!(
+                        "pin `{pin}` on cell `{}` in module `{}` contains empty constant",
+                        self.cell_name, self.module_name
+                    );
+                }
+                for ch in text.chars() {
+                    bits.push(yosys_bridge::bitref::RtlilBit::Const(ch));
+                }
+                Ok(())
+            }
+            other => bail!(
+                "unsupported connection element `{other}` for pin `{pin}` on cell `{}` in module `{}`",
+                self.cell_name,
+                self.module_name
+            ),
+        }
+    }
+
+    fn missing_pin_error(&self, pin: &str) -> anyhow::Error {
+        anyhow!(
+            "cell `{}` in module `{}` is missing connection for pin `{}`",
+            self.cell_name,
+            self.module_name,
+            pin
+        )
+    }
+}
+
+pub fn convert_bitref(source: &yosys_bridge::bitref::BitRef) -> BitRef {
+    match source {
+        yosys_bridge::bitref::BitRef::Slice { net, lsb, msb } => BitRef::Net(BitRefNet {
+            net: net.clone(),
+            lsb: *lsb,
+            msb: *msb,
+        }),
+        yosys_bridge::bitref::BitRef::Const { value, width } => BitRef::Const(BitRefConst {
+            value: value.clone(),
+            width: *width,
+        }),
+        yosys_bridge::bitref::BitRef::Concat { parts } => BitRef::Concat(BitRefConcat {
+            concat: parts.iter().map(convert_bitref).collect(),
+        }),
+    }
+}
+
+pub type BitLookupMap = BitLookup;

--- a/v2m/frontends/yosys_bridge/src/lib.rs
+++ b/v2m/frontends/yosys_bridge/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod cells;
+mod context;
+mod module;
+mod nir_node;
+
+pub use module::{rtlil_to_nir, ModuleBuilder};
+pub use nir_node::NirNode;

--- a/v2m/frontends/yosys_bridge/src/module.rs
+++ b/v2m/frontends/yosys_bridge/src/module.rs
@@ -1,0 +1,269 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::{Map, Value};
+use v2m_formats::nir::{Module as NirModule, Net as NirNet, Nir, Port as NirPort, PortDirection};
+
+use crate::cells;
+use crate::context::{BitLookupMap, Ctx, NetBitInfo};
+use crate::nir_node::NirNode;
+
+pub struct ModuleBuilder<'a> {
+    module_name: &'a str,
+    module: &'a yosys_bridge::loader::Module,
+    bit_lookup: BitLookupMap,
+    nets: BTreeMap<String, NirNet>,
+}
+
+impl<'a> ModuleBuilder<'a> {
+    pub fn new(module_name: &'a str, module: &'a yosys_bridge::loader::Module) -> Result<Self> {
+        let (nets, bit_lookup) = build_nets(module_name, &module.netnames)?;
+        Ok(Self {
+            module_name,
+            module,
+            bit_lookup,
+            nets,
+        })
+    }
+
+    pub fn build(self) -> Result<NirModule> {
+        let ports = build_ports(self.module_name, &self.module.ports)?;
+        let nodes = self.build_nodes()?;
+        Ok(NirModule {
+            ports,
+            nets: self.nets,
+            nodes,
+        })
+    }
+
+    fn build_nodes(&self) -> Result<BTreeMap<String, v2m_formats::nir::Node>> {
+        let mut nodes = BTreeMap::new();
+        for (cell_name, cell) in &self.module.cells {
+            let nir_node = map_cell(self.module_name, cell_name, cell, &self.bit_lookup)?;
+            nodes.insert(cell_name.clone(), nir_node.into_node(cell_name.clone()));
+        }
+        Ok(nodes)
+    }
+}
+
+pub fn rtlil_to_nir(design: &yosys_bridge::loader::RtlilJson) -> Result<Nir> {
+    let mut modules = BTreeMap::new();
+    for (name, module) in &design.modules {
+        let builder = ModuleBuilder::new(name, module)?;
+        let nir_module = builder.build()?;
+        modules.insert(name.clone(), nir_module);
+    }
+
+    Ok(Nir {
+        v: "nir-1.1".to_string(),
+        design: design.top.clone(),
+        top: design.top.clone(),
+        attrs: None,
+        modules,
+        generator: None,
+        cmdline: None,
+        source_digest_sha256: None,
+    })
+}
+
+fn map_cell(
+    module_name: &str,
+    cell_name: &str,
+    cell: &yosys_bridge::loader::Cell,
+    bit_lookup: &BitLookupMap,
+) -> Result<NirNode> {
+    let mut ctx = Ctx::new(module_name, cell_name, bit_lookup);
+    match cell.kind.as_str() {
+        "$and" => cells::logic::map_and(cell, &mut ctx),
+        "$or" => cells::logic::map_or(cell, &mut ctx),
+        "$xor" => cells::logic::map_xor(cell, &mut ctx),
+        "$xnor" => cells::logic::map_xnor(cell, &mut ctx),
+        "$not" => cells::logic::map_not(cell, &mut ctx),
+        "$mux" => cells::logic::map_mux(cell, &mut ctx),
+        "$add" => cells::arith::map_add(cell, &mut ctx),
+        "$sub" => cells::arith::map_sub(cell, &mut ctx),
+        other => bail!("unsupported cell `{other}` in module `{module_name}` while mapping to NIR"),
+    }
+}
+
+fn build_ports(
+    module_name: &str,
+    ports: &BTreeMap<String, Value>,
+) -> Result<BTreeMap<String, NirPort>> {
+    let mut result = BTreeMap::new();
+    for (name, value) in ports {
+        let obj = value
+            .as_object()
+            .ok_or_else(|| anyhow!("port `{name}` in module `{module_name}` must be an object"))?;
+        let direction_value = obj
+            .get("direction")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                anyhow!("port `{name}` in module `{module_name}` is missing `direction`")
+            })?;
+        let bits_value = obj
+            .get("bits")
+            .ok_or_else(|| anyhow!("port `{name}` in module `{module_name}` is missing `bits`"))?;
+
+        let bits = collect_bit_ids(bits_value).with_context(|| {
+            format!("port `{name}` in module `{module_name}` has invalid `bits`")
+        })?;
+        if bits.is_empty() {
+            bail!("port `{name}` in module `{module_name}` does not reference any bits");
+        }
+        let width = u32::try_from(bits.len()).context("port width exceeds supported range")?;
+        let dir = match direction_value {
+            "input" => PortDirection::Input,
+            "output" => PortDirection::Output,
+            "inout" => PortDirection::Inout,
+            other => {
+                bail!("port `{name}` in module `{module_name}` has unsupported direction `{other}`")
+            }
+        };
+
+        result.insert(
+            normalize_name(name),
+            NirPort {
+                dir,
+                bits: width,
+                attrs: None,
+            },
+        );
+    }
+    Ok(result)
+}
+
+fn build_nets(
+    module_name: &str,
+    netnames: &BTreeMap<String, Value>,
+) -> Result<(BTreeMap<String, NirNet>, BitLookupMap)> {
+    let mut nets = BTreeMap::new();
+    let mut lookup: HashMap<i64, NetBitInfo> = HashMap::new();
+
+    for (raw_name, value) in netnames {
+        let obj = value.as_object().ok_or_else(|| {
+            anyhow!("net `{raw_name}` in module `{module_name}` must be an object")
+        })?;
+        let bits_value = obj.get("bits").ok_or_else(|| {
+            anyhow!("net `{raw_name}` in module `{module_name}` is missing `bits`")
+        })?;
+        let bit_ids = collect_bit_ids(bits_value).with_context(|| {
+            format!("net `{raw_name}` in module `{module_name}` has invalid `bits`")
+        })?;
+        if bit_ids.is_empty() {
+            bail!("net `{raw_name}` in module `{module_name}` contains no bits");
+        }
+        let width = u32::try_from(bit_ids.len()).context("net width exceeds supported range")?;
+        let normalized = normalize_name(raw_name);
+
+        for (offset, bit_id) in bit_ids.into_iter().enumerate() {
+            let offset_u32 = u32::try_from(offset).context("net bit offset exceeds range")?;
+            if lookup
+                .insert(
+                    bit_id,
+                    NetBitInfo {
+                        net: normalized.clone(),
+                        offset: offset_u32,
+                    },
+                )
+                .is_some()
+            {
+                bail!("bit id {bit_id} referenced by multiple nets in module `{module_name}`");
+            }
+        }
+
+        nets.insert(
+            normalized,
+            NirNet {
+                bits: width,
+                attrs: None,
+            },
+        );
+    }
+
+    Ok((nets, lookup))
+}
+
+fn collect_bit_ids(value: &Value) -> Result<Vec<i64>> {
+    let mut bits = Vec::new();
+    collect_bit_ids_inner(value, &mut bits)?;
+    Ok(bits)
+}
+
+fn collect_bit_ids_inner(value: &Value, bits: &mut Vec<i64>) -> Result<()> {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_bit_ids_inner(item, bits)?;
+            }
+            Ok(())
+        }
+        Value::Number(num) => {
+            let bit_id = num
+                .as_i64()
+                .ok_or_else(|| anyhow!("connection bit index `{num}` is not an integer"))?;
+            bits.push(bit_id);
+            Ok(())
+        }
+        other => bail!("unsupported bit entry `{other}`"),
+    }
+}
+
+fn normalize_name(raw: &str) -> String {
+    raw.strip_prefix('\\').unwrap_or(raw).to_string()
+}
+
+#[allow(dead_code)]
+fn value_is_truthy(value: &Value) -> bool {
+    match value {
+        Value::Bool(v) => *v,
+        Value::Number(num) => {
+            if let Some(i) = num.as_i64() {
+                i != 0
+            } else if let Some(u) = num.as_u64() {
+                u != 0
+            } else if let Some(f) = num.as_f64() {
+                f != 0.0
+            } else {
+                false
+            }
+        }
+        Value::String(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                false
+            } else {
+                let lower = trimmed.to_ascii_lowercase();
+                lower != "0" && lower != "false"
+            }
+        }
+        _ => false,
+    }
+}
+
+fn net_is_signed(obj: &Map<String, Value>) -> bool {
+    if let Some(flag) = obj.get("signed") {
+        if value_is_truthy(flag) {
+            return true;
+        }
+    }
+    if let Some(attributes) = obj.get("attributes").and_then(Value::as_object) {
+        if let Some(flag) = attributes.get("signed") {
+            if value_is_truthy(flag) {
+                return true;
+            }
+        }
+        if let Some(flag) = attributes.get("\\signed") {
+            if value_is_truthy(flag) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// Placeholder to silence unused warning until signedness is used.
+#[allow(dead_code)]
+fn _maybe_use_signedness(obj: &Map<String, Value>) {
+    let _ = net_is_signed(obj);
+}

--- a/v2m/frontends/yosys_bridge/src/nir_node.rs
+++ b/v2m/frontends/yosys_bridge/src/nir_node.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use v2m_formats::nir::{BitRef, Node, NodeOp};
+
+#[derive(Debug, Clone)]
+pub struct NirNode {
+    pub op: NodeOp,
+    pub width: u32,
+    pub pin_map: BTreeMap<String, BitRef>,
+    pub attrs: Option<BTreeMap<String, Value>>,
+}
+
+impl NirNode {
+    pub fn new(op: NodeOp, width: u32, pin_map: BTreeMap<String, BitRef>) -> Self {
+        Self {
+            op,
+            width,
+            pin_map,
+            attrs: None,
+        }
+    }
+
+    pub fn with_attrs(mut self, attrs: BTreeMap<String, Value>) -> Self {
+        self.attrs = if attrs.is_empty() { None } else { Some(attrs) };
+        self
+    }
+
+    pub fn into_node(self, uid: String) -> Node {
+        Node {
+            uid,
+            op: self.op,
+            width: self.width,
+            pin_map: self.pin_map,
+            params: None,
+            attrs: self.attrs,
+        }
+    }
+}

--- a/v2m/frontends/yosys_bridge/tests/nir_mapping.rs
+++ b/v2m/frontends/yosys_bridge/tests/nir_mapping.rs
@@ -1,0 +1,329 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use frontends_yosys_bridge::rtlil_to_nir;
+use insta::assert_json_snapshot;
+use serde_json::{json, Value};
+use yosys_bridge::loader::{Cell, Module, RtlilJson};
+
+#[test]
+fn alu4_sample_to_nir_snapshot() -> Result<()> {
+    let design = alu4_design();
+    let nir = rtlil_to_nir(&design)?;
+    let value = serde_json::to_value(&nir)?;
+    assert_json_snapshot!("alu4_sample", value);
+    Ok(())
+}
+
+#[test]
+fn mux_tree_sample_to_nir_snapshot() -> Result<()> {
+    let design = mux_tree_design();
+    let nir = rtlil_to_nir(&design)?;
+    let value = serde_json::to_value(&nir)?;
+    assert_json_snapshot!("mux_tree_sample", value);
+    Ok(())
+}
+
+fn alu4_design() -> RtlilJson {
+    let mut ports = BTreeMap::new();
+    ports.insert("a".to_string(), port(&[1, 2, 3, 4], "input"));
+    ports.insert("b".to_string(), port(&[5, 6, 7, 8], "input"));
+    ports.insert("op".to_string(), port(&[9, 10], "input"));
+    ports.insert("y".to_string(), port(&[35, 36, 37, 38], "output"));
+
+    let mut netnames = BTreeMap::new();
+    netnames.insert("a".to_string(), net(&[1, 2, 3, 4]));
+    netnames.insert("b".to_string(), net(&[5, 6, 7, 8]));
+    netnames.insert("op".to_string(), net(&[9, 10]));
+    netnames.insert("sum".to_string(), net(&[11, 12, 13, 14]));
+    netnames.insert("and_ab".to_string(), net(&[15, 16, 17, 18]));
+    netnames.insert("or_ab".to_string(), net(&[19, 20, 21, 22]));
+    netnames.insert("xor_ab".to_string(), net(&[23, 24, 25, 26]));
+    netnames.insert("lo_sel".to_string(), net(&[27, 28, 29, 30]));
+    netnames.insert("hi_sel".to_string(), net(&[31, 32, 33, 34]));
+    netnames.insert("y".to_string(), net(&[35, 36, 37, 38]));
+
+    let mut cells = BTreeMap::new();
+    cells.insert(
+        "add_sum".to_string(),
+        add_cell(
+            &[
+                ("A", &[1, 2, 3, 4]),
+                ("B", &[5, 6, 7, 8]),
+                ("Y", &[11, 12, 13, 14]),
+            ],
+            4,
+            4,
+            4,
+        ),
+    );
+    cells.insert(
+        "and_node".to_string(),
+        bitwise_cell(
+            "$and",
+            &[
+                ("A", &[1, 2, 3, 4]),
+                ("B", &[5, 6, 7, 8]),
+                ("Y", &[15, 16, 17, 18]),
+            ],
+            4,
+        ),
+    );
+    cells.insert(
+        "or_node".to_string(),
+        bitwise_cell(
+            "$or",
+            &[
+                ("A", &[1, 2, 3, 4]),
+                ("B", &[5, 6, 7, 8]),
+                ("Y", &[19, 20, 21, 22]),
+            ],
+            4,
+        ),
+    );
+    cells.insert(
+        "xor_node".to_string(),
+        bitwise_cell(
+            "$xor",
+            &[
+                ("A", &[1, 2, 3, 4]),
+                ("B", &[5, 6, 7, 8]),
+                ("Y", &[23, 24, 25, 26]),
+            ],
+            4,
+        ),
+    );
+    cells.insert(
+        "mux_lo".to_string(),
+        mux_cell(
+            &[
+                ("A", &[11, 12, 13, 14]),
+                ("B", &[15, 16, 17, 18]),
+                ("S", &[9]),
+                ("Y", &[27, 28, 29, 30]),
+            ],
+            4,
+            1,
+        ),
+    );
+    cells.insert(
+        "mux_hi".to_string(),
+        mux_cell(
+            &[
+                ("A", &[19, 20, 21, 22]),
+                ("B", &[23, 24, 25, 26]),
+                ("S", &[9]),
+                ("Y", &[31, 32, 33, 34]),
+            ],
+            4,
+            1,
+        ),
+    );
+    cells.insert(
+        "mux_final".to_string(),
+        mux_cell(
+            &[
+                ("A", &[27, 28, 29, 30]),
+                ("B", &[31, 32, 33, 34]),
+                ("S", &[10]),
+                ("Y", &[35, 36, 37, 38]),
+            ],
+            4,
+            1,
+        ),
+    );
+
+    let module = Module {
+        attributes: BTreeMap::new(),
+        ports,
+        cells,
+        netnames,
+    };
+
+    RtlilJson {
+        top: "alu4".to_string(),
+        modules: BTreeMap::from([(module_name("alu4"), module)]),
+    }
+}
+
+fn mux_tree_design() -> RtlilJson {
+    let mut ports = BTreeMap::new();
+    ports.insert("in0".to_string(), port(&[100, 101, 102, 103], "input"));
+    ports.insert("in1".to_string(), port(&[104, 105, 106, 107], "input"));
+    ports.insert("in2".to_string(), port(&[108, 109, 110, 111], "input"));
+    ports.insert("in3".to_string(), port(&[112, 113, 114, 115], "input"));
+    ports.insert("sel".to_string(), port(&[116, 117], "input"));
+    ports.insert("y".to_string(), port(&[140, 141, 142, 143], "output"));
+
+    let mut netnames = BTreeMap::new();
+    netnames.insert("in0".to_string(), net(&[100, 101, 102, 103]));
+    netnames.insert("in1".to_string(), net(&[104, 105, 106, 107]));
+    netnames.insert("in2".to_string(), net(&[108, 109, 110, 111]));
+    netnames.insert("in3".to_string(), net(&[112, 113, 114, 115]));
+    netnames.insert("sel".to_string(), net(&[116, 117]));
+    netnames.insert("not_in0".to_string(), net(&[118, 119, 120, 121]));
+    netnames.insert("xnor_in1_in2".to_string(), net(&[122, 123, 124, 125]));
+    netnames.insert("diff".to_string(), net(&[126, 127, 128, 129]));
+    netnames.insert("mux_lo".to_string(), net(&[130, 131, 132, 133]));
+    netnames.insert("mux_hi".to_string(), net(&[134, 135, 136, 137]));
+    netnames.insert("y".to_string(), net(&[140, 141, 142, 143]));
+
+    let mut cells = BTreeMap::new();
+    cells.insert(
+        "not_in0".to_string(),
+        not_cell(
+            &[("A", &[100, 101, 102, 103]), ("Y", &[118, 119, 120, 121])],
+            4,
+        ),
+    );
+    cells.insert(
+        "xnor_inputs".to_string(),
+        bitwise_cell(
+            "$xnor",
+            &[
+                ("A", &[104, 105, 106, 107]),
+                ("B", &[108, 109, 110, 111]),
+                ("Y", &[122, 123, 124, 125]),
+            ],
+            4,
+        ),
+    );
+    cells.insert(
+        "sub_inputs".to_string(),
+        sub_cell(
+            &[
+                ("A", &[112, 113, 114, 115]),
+                ("B", &[108, 109, 110, 111]),
+                ("Y", &[126, 127, 128, 129]),
+            ],
+            4,
+            4,
+            4,
+        ),
+    );
+    cells.insert(
+        "mux_level0".to_string(),
+        mux_cell(
+            &[
+                ("A", &[118, 119, 120, 121]),
+                ("B", &[122, 123, 124, 125]),
+                ("S", &[116]),
+                ("Y", &[130, 131, 132, 133]),
+            ],
+            4,
+            1,
+        ),
+    );
+    cells.insert(
+        "mux_level1".to_string(),
+        mux_cell(
+            &[
+                ("A", &[126, 127, 128, 129]),
+                ("B", &[112, 113, 114, 115]),
+                ("S", &[116]),
+                ("Y", &[134, 135, 136, 137]),
+            ],
+            4,
+            1,
+        ),
+    );
+    cells.insert(
+        "mux_final".to_string(),
+        mux_cell(
+            &[
+                ("A", &[130, 131, 132, 133]),
+                ("B", &[134, 135, 136, 137]),
+                ("S", &[117]),
+                ("Y", &[140, 141, 142, 143]),
+            ],
+            4,
+            1,
+        ),
+    );
+
+    let module = Module {
+        attributes: BTreeMap::new(),
+        ports,
+        cells,
+        netnames,
+    };
+
+    RtlilJson {
+        top: "mux_tree".to_string(),
+        modules: BTreeMap::from([(module_name("mux_tree"), module)]),
+    }
+}
+
+fn add_cell(connections: &[(&str, &[i64])], a_width: u32, b_width: u32, y_width: u32) -> Cell {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("A_WIDTH".to_string(), json!(a_width));
+    parameters.insert("B_WIDTH".to_string(), json!(b_width));
+    parameters.insert("Y_WIDTH".to_string(), json!(y_width));
+    parameters.insert("A_SIGNED".to_string(), json!(false));
+    parameters.insert("B_SIGNED".to_string(), json!(false));
+    parameters.insert("Y_SIGNED".to_string(), json!(false));
+    make_cell("$add", parameters, connections)
+}
+
+fn sub_cell(connections: &[(&str, &[i64])], a_width: u32, b_width: u32, y_width: u32) -> Cell {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("A_WIDTH".to_string(), json!(a_width));
+    parameters.insert("B_WIDTH".to_string(), json!(b_width));
+    parameters.insert("Y_WIDTH".to_string(), json!(y_width));
+    parameters.insert("A_SIGNED".to_string(), json!(false));
+    parameters.insert("B_SIGNED".to_string(), json!(false));
+    parameters.insert("Y_SIGNED".to_string(), json!(false));
+    make_cell("$sub", parameters, connections)
+}
+
+fn bitwise_cell(kind: &str, connections: &[(&str, &[i64])], width: u32) -> Cell {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("A_WIDTH".to_string(), json!(width));
+    parameters.insert("B_WIDTH".to_string(), json!(width));
+    parameters.insert("Y_WIDTH".to_string(), json!(width));
+    make_cell(kind, parameters, connections)
+}
+
+fn not_cell(connections: &[(&str, &[i64])], width: u32) -> Cell {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("A_WIDTH".to_string(), json!(width));
+    parameters.insert("Y_WIDTH".to_string(), json!(width));
+    make_cell("$not", parameters, connections)
+}
+
+fn mux_cell(connections: &[(&str, &[i64])], width: u32, select_width: u32) -> Cell {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("WIDTH".to_string(), json!(width));
+    parameters.insert("S_WIDTH".to_string(), json!(select_width));
+    make_cell("$mux", parameters, connections)
+}
+
+fn make_cell(
+    kind: &str,
+    parameters: BTreeMap<String, Value>,
+    connections: &[(&str, &[i64])],
+) -> Cell {
+    let mut connections_map = BTreeMap::new();
+    for (pin, bits) in connections {
+        connections_map.insert((*pin).to_string(), json!(bits));
+    }
+
+    Cell {
+        kind: kind.to_string(),
+        parameters,
+        attributes: BTreeMap::new(),
+        connections: connections_map,
+    }
+}
+
+fn port(bits: &[i64], direction: &str) -> Value {
+    json!({ "direction": direction, "bits": bits })
+}
+
+fn net(bits: &[i64]) -> Value {
+    json!({ "bits": bits })
+}
+
+fn module_name(name: &str) -> String {
+    name.to_string()
+}

--- a/v2m/frontends/yosys_bridge/tests/snapshots/nir_mapping__alu4_sample.snap
+++ b/v2m/frontends/yosys_bridge/tests/snapshots/nir_mapping__alu4_sample.snap
@@ -1,0 +1,243 @@
+---
+source: frontends/yosys_bridge/tests/nir_mapping.rs
+assertion_line: 14
+expression: value
+---
+{
+  "design": "alu4",
+  "modules": {
+    "alu4": {
+      "nets": {
+        "a": {
+          "bits": 4
+        },
+        "and_ab": {
+          "bits": 4
+        },
+        "b": {
+          "bits": 4
+        },
+        "hi_sel": {
+          "bits": 4
+        },
+        "lo_sel": {
+          "bits": 4
+        },
+        "op": {
+          "bits": 2
+        },
+        "or_ab": {
+          "bits": 4
+        },
+        "sum": {
+          "bits": 4
+        },
+        "xor_ab": {
+          "bits": 4
+        },
+        "y": {
+          "bits": 4
+        }
+      },
+      "nodes": {
+        "add_sum": {
+          "attrs": {
+            "A_SIGNED": false,
+            "A_WIDTH": 4,
+            "B_SIGNED": false,
+            "B_WIDTH": 4,
+            "Y_SIGNED": false,
+            "Y_WIDTH": 4
+          },
+          "op": "ADD",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "a"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "b"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "sum"
+            }
+          },
+          "uid": "add_sum",
+          "width": 4
+        },
+        "and_node": {
+          "op": "AND",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "a"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "b"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "and_ab"
+            }
+          },
+          "uid": "and_node",
+          "width": 4
+        },
+        "mux_final": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "lo_sel"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "hi_sel"
+            },
+            "S": {
+              "lsb": 1,
+              "msb": 1,
+              "net": "op"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "y"
+            }
+          },
+          "uid": "mux_final",
+          "width": 4
+        },
+        "mux_hi": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "or_ab"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "xor_ab"
+            },
+            "S": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "op"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "hi_sel"
+            }
+          },
+          "uid": "mux_hi",
+          "width": 4
+        },
+        "mux_lo": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "sum"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "and_ab"
+            },
+            "S": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "op"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "lo_sel"
+            }
+          },
+          "uid": "mux_lo",
+          "width": 4
+        },
+        "or_node": {
+          "op": "OR",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "a"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "b"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "or_ab"
+            }
+          },
+          "uid": "or_node",
+          "width": 4
+        },
+        "xor_node": {
+          "op": "XOR",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "a"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "b"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "xor_ab"
+            }
+          },
+          "uid": "xor_node",
+          "width": 4
+        }
+      },
+      "ports": {
+        "a": {
+          "bits": 4,
+          "dir": "input"
+        },
+        "b": {
+          "bits": 4,
+          "dir": "input"
+        },
+        "op": {
+          "bits": 2,
+          "dir": "input"
+        },
+        "y": {
+          "bits": 4,
+          "dir": "output"
+        }
+      }
+    }
+  },
+  "top": "alu4",
+  "v": "nir-1.1"
+}

--- a/v2m/frontends/yosys_bridge/tests/snapshots/nir_mapping__mux_tree_sample.snap
+++ b/v2m/frontends/yosys_bridge/tests/snapshots/nir_mapping__mux_tree_sample.snap
@@ -1,0 +1,227 @@
+---
+source: frontends/yosys_bridge/tests/nir_mapping.rs
+assertion_line: 23
+expression: value
+---
+{
+  "design": "mux_tree",
+  "modules": {
+    "mux_tree": {
+      "nets": {
+        "diff": {
+          "bits": 4
+        },
+        "in0": {
+          "bits": 4
+        },
+        "in1": {
+          "bits": 4
+        },
+        "in2": {
+          "bits": 4
+        },
+        "in3": {
+          "bits": 4
+        },
+        "mux_hi": {
+          "bits": 4
+        },
+        "mux_lo": {
+          "bits": 4
+        },
+        "not_in0": {
+          "bits": 4
+        },
+        "sel": {
+          "bits": 2
+        },
+        "xnor_in1_in2": {
+          "bits": 4
+        },
+        "y": {
+          "bits": 4
+        }
+      },
+      "nodes": {
+        "mux_final": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "mux_lo"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "mux_hi"
+            },
+            "S": {
+              "lsb": 1,
+              "msb": 1,
+              "net": "sel"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "y"
+            }
+          },
+          "uid": "mux_final",
+          "width": 4
+        },
+        "mux_level0": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "not_in0"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "xnor_in1_in2"
+            },
+            "S": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "sel"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "mux_lo"
+            }
+          },
+          "uid": "mux_level0",
+          "width": 4
+        },
+        "mux_level1": {
+          "op": "MUX",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "diff"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "in3"
+            },
+            "S": {
+              "lsb": 0,
+              "msb": 0,
+              "net": "sel"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "mux_hi"
+            }
+          },
+          "uid": "mux_level1",
+          "width": 4
+        },
+        "not_in0": {
+          "op": "NOT",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "in0"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "not_in0"
+            }
+          },
+          "uid": "not_in0",
+          "width": 4
+        },
+        "sub_inputs": {
+          "attrs": {
+            "A_SIGNED": false,
+            "A_WIDTH": 4,
+            "B_SIGNED": false,
+            "B_WIDTH": 4,
+            "Y_SIGNED": false,
+            "Y_WIDTH": 4
+          },
+          "op": "SUB",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "in3"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "in2"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "diff"
+            }
+          },
+          "uid": "sub_inputs",
+          "width": 4
+        },
+        "xnor_inputs": {
+          "op": "XNOR",
+          "pin_map": {
+            "A": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "in1"
+            },
+            "B": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "in2"
+            },
+            "Y": {
+              "lsb": 0,
+              "msb": 3,
+              "net": "xnor_in1_in2"
+            }
+          },
+          "uid": "xnor_inputs",
+          "width": 4
+        }
+      },
+      "ports": {
+        "in0": {
+          "bits": 4,
+          "dir": "input"
+        },
+        "in1": {
+          "bits": 4,
+          "dir": "input"
+        },
+        "in2": {
+          "bits": 4,
+          "dir": "input"
+        },
+        "in3": {
+          "bits": 4,
+          "dir": "input"
+        },
+        "sel": {
+          "bits": 2,
+          "dir": "input"
+        },
+        "y": {
+          "bits": 4,
+          "dir": "output"
+        }
+      }
+    }
+  },
+  "top": "mux_tree",
+  "v": "nir-1.1"
+}


### PR DESCRIPTION
## Summary
- map logic and arithmetic Yosys cells to normalized NIR nodes with shared helpers
- carry arithmetic width and signedness metadata into node attributes
- add snapshot-based tests that exercise ALU and mux-tree conversions

## Testing
- cargo test -p frontends-yosys-bridge

------
https://chatgpt.com/codex/tasks/task_e_68cc6cda18f88323be9c6cbbf16ad2fd