### PR TITLE
Lower comparator cells into logic

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -477,8 +477,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "insta",
+ "rand 0.8.5",
  "serde",
  "serde_json",
+ "v2m-evaluator",
  "v2m-formats",
  "yosys-bridge",
 ]

--- a/v2m/crates/yosys-bridge/tests/fixtures/has_cmp.json
+++ b/v2m/crates/yosys-bridge/tests/fixtures/has_cmp.json
@@ -1,0 +1,37 @@
+{
+  "modules": {
+    "compare_block": {
+      "attributes": {
+        "top": 1
+      },
+      "ports": {
+        "a": { "direction": "input", "bits": [1, 2] },
+        "b": { "direction": "input", "bits": [3, 4] },
+        "y": { "direction": "output", "bits": [5] }
+      },
+      "cells": {
+        "cmp": {
+          "type": "$eq",
+          "attributes": {},
+          "parameters": {
+            "A_WIDTH": 2,
+            "B_WIDTH": 2,
+            "Y_WIDTH": 1,
+            "A_SIGNED": 0,
+            "B_SIGNED": 0
+          },
+          "connections": {
+            "A": [1, 2],
+            "B": [3, 4],
+            "Y": [5]
+          }
+        }
+      },
+      "netnames": {
+        "a": { "bits": [1, 2], "attributes": {} },
+        "b": { "bits": [3, 4], "attributes": {} },
+        "y": { "bits": [5], "attributes": {} }
+      }
+    }
+  }
+}

--- a/v2m/crates/yosys-bridge/tests/loader.rs
+++ b/v2m/crates/yosys-bridge/tests/loader.rs
@@ -53,6 +53,25 @@ fn allow_mem_blackbox_bypasses_memory_check() {
 }
 
 #[test]
+fn detects_remaining_comparator_cells_when_disallowed() {
+    let mut options = LoaderOptions::default();
+    options.allow_comparator_cells = false;
+
+    let error = load_rtlil_json(fixture_path("has_cmp.json"), &options)
+        .expect_err("expect comparator cell error");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("$eq"),
+        "error missing comparator info: {message}"
+    );
+    assert!(
+        message.contains("--no-expand"),
+        "error should hint about --no-expand: {message}"
+    );
+}
+
+#[test]
 fn errors_when_top_module_missing() {
     let error = load_rtlil_json(fixture_path("missing_top.json"), &LoaderOptions::default())
         .expect_err("expect top module error");

--- a/v2m/frontends/yosys_bridge/Cargo.toml
+++ b/v2m/frontends/yosys_bridge/Cargo.toml
@@ -13,3 +13,5 @@ v2m-formats = { path = "../../core/formats" }
 
 [dev-dependencies]
 insta = { workspace = true }
+rand = { workspace = true }
+v2m-evaluator = { path = "../../evaluator" }

--- a/v2m/frontends/yosys_bridge/src/cells/compare.rs
+++ b/v2m/frontends/yosys_bridge/src/cells/compare.rs
@@ -1,0 +1,620 @@
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, bail, ensure, Result};
+
+use v2m_formats::nir::{BitRef, BitRefConcat, BitRefConst, BitRefNet, Net as NirNet, NodeOp};
+
+use crate::cells::{expect_param_bool, expect_param_u32, LoweredCell};
+use crate::context::Ctx;
+use crate::nir_node::NirNode;
+use yosys_bridge::loader::Cell;
+
+#[derive(Clone)]
+struct CompareSignals {
+    eq: BitRef,
+    lt: BitRef,
+    gt: BitRef,
+}
+
+pub fn map_eq(cell: &Cell, ctx: &mut Ctx) -> Result<LoweredCell> {
+    let operands = ComparatorOperands::new(cell, ctx)?;
+    let mut builder = CellLoweringBuilder::new(ctx.cell_name());
+
+    if operands.width == 0 {
+        builder.assign_with_name(ctx.cell_name(), one_bit(), operands.y_bit.clone());
+        return Ok(builder.finish());
+    }
+
+    let a_bits = builder.materialize_bits(&operands.a_bits);
+    let b_bits = builder.materialize_bits(&operands.b_bits);
+    let eq_bit = build_equality_bit(&mut builder, &a_bits, &b_bits)?;
+    builder.assign_with_name(ctx.cell_name(), eq_bit, operands.y_bit.clone());
+    Ok(builder.finish())
+}
+
+pub fn map_ne(cell: &Cell, ctx: &mut Ctx) -> Result<LoweredCell> {
+    let operands = ComparatorOperands::new(cell, ctx)?;
+    let mut builder = CellLoweringBuilder::new(ctx.cell_name());
+
+    if operands.width == 0 {
+        builder.assign_with_name(ctx.cell_name(), zero_bit(), operands.y_bit.clone());
+        return Ok(builder.finish());
+    }
+
+    let a_bits = builder.materialize_bits(&operands.a_bits);
+    let b_bits = builder.materialize_bits(&operands.b_bits);
+    let eq_bit = build_equality_bit(&mut builder, &a_bits, &b_bits)?;
+    builder.emit_named_unop(
+        Some(ctx.cell_name()),
+        NodeOp::Not,
+        eq_bit,
+        operands.y_bit.clone(),
+    );
+    Ok(builder.finish())
+}
+
+pub fn map_lt(cell: &Cell, ctx: &mut Ctx) -> Result<LoweredCell> {
+    let operands = ComparatorOperands::new(cell, ctx)?;
+    let mut builder = CellLoweringBuilder::new(ctx.cell_name());
+
+    if operands.width == 0 {
+        builder.assign_with_name(ctx.cell_name(), zero_bit(), operands.y_bit.clone());
+        return Ok(builder.finish());
+    }
+
+    let a_bits = builder.materialize_bits(&operands.a_bits);
+    let b_bits = builder.materialize_bits(&operands.b_bits);
+    let cmp = build_unsigned_compare(&mut builder, &a_bits, &b_bits)?;
+    let result = if operands.is_signed_relational() {
+        let terms = build_signed_terms(
+            &mut builder,
+            &a_bits,
+            &b_bits,
+            operands.a_signed,
+            operands.b_signed,
+        );
+        signed_lt(&mut builder, &cmp, &terms)
+    } else {
+        cmp.lt
+    };
+    builder.assign_with_name(ctx.cell_name(), result, operands.y_bit.clone());
+    Ok(builder.finish())
+}
+
+pub fn map_le(cell: &Cell, ctx: &mut Ctx) -> Result<LoweredCell> {
+    let operands = ComparatorOperands::new(cell, ctx)?;
+    let mut builder = CellLoweringBuilder::new(ctx.cell_name());
+
+    if operands.width == 0 {
+        builder.assign_with_name(ctx.cell_name(), one_bit(), operands.y_bit.clone());
+        return Ok(builder.finish());
+    }
+
+    let a_bits = builder.materialize_bits(&operands.a_bits);
+    let b_bits = builder.materialize_bits(&operands.b_bits);
+    let cmp = build_unsigned_compare(&mut builder, &a_bits, &b_bits)?;
+    let (lt_bit, eq_bit) = if operands.is_signed_relational() {
+        let terms = build_signed_terms(
+            &mut builder,
+            &a_bits,
+            &b_bits,
+            operands.a_signed,
+            operands.b_signed,
+        );
+        let lt = signed_lt(&mut builder, &cmp, &terms);
+        let eq = builder.emit_binop(NodeOp::And, cmp.eq.clone(), terms.sign_same.clone(), 1);
+        (lt, eq)
+    } else {
+        (cmp.lt.clone(), cmp.eq.clone())
+    };
+    let le_bit = builder.emit_binop(NodeOp::Or, lt_bit, eq_bit, 1);
+    builder.assign_with_name(ctx.cell_name(), le_bit, operands.y_bit.clone());
+    Ok(builder.finish())
+}
+
+pub fn map_gt(cell: &Cell, ctx: &mut Ctx) -> Result<LoweredCell> {
+    let operands = ComparatorOperands::new(cell, ctx)?;
+    let mut builder = CellLoweringBuilder::new(ctx.cell_name());
+
+    if operands.width == 0 {
+        builder.assign_with_name(ctx.cell_name(), zero_bit(), operands.y_bit.clone());
+        return Ok(builder.finish());
+    }
+
+    let a_bits = builder.materialize_bits(&operands.a_bits);
+    let b_bits = builder.materialize_bits(&operands.b_bits);
+    let cmp = build_unsigned_compare(&mut builder, &a_bits, &b_bits)?;
+    let result = if operands.is_signed_relational() {
+        let terms = build_signed_terms(
+            &mut builder,
+            &a_bits,
+            &b_bits,
+            operands.a_signed,
+            operands.b_signed,
+        );
+        signed_gt(&mut builder, &cmp, &terms)
+    } else {
+        cmp.gt
+    };
+    builder.assign_with_name(ctx.cell_name(), result, operands.y_bit.clone());
+    Ok(builder.finish())
+}
+
+pub fn map_ge(cell: &Cell, ctx: &mut Ctx) -> Result<LoweredCell> {
+    let operands = ComparatorOperands::new(cell, ctx)?;
+    let mut builder = CellLoweringBuilder::new(ctx.cell_name());
+
+    if operands.width == 0 {
+        builder.assign_with_name(ctx.cell_name(), one_bit(), operands.y_bit.clone());
+        return Ok(builder.finish());
+    }
+
+    let a_bits = builder.materialize_bits(&operands.a_bits);
+    let b_bits = builder.materialize_bits(&operands.b_bits);
+    let cmp = build_unsigned_compare(&mut builder, &a_bits, &b_bits)?;
+    let (gt_bit, eq_bit) = if operands.is_signed_relational() {
+        let terms = build_signed_terms(
+            &mut builder,
+            &a_bits,
+            &b_bits,
+            operands.a_signed,
+            operands.b_signed,
+        );
+        let gt = signed_gt(&mut builder, &cmp, &terms);
+        let eq = builder.emit_binop(NodeOp::And, cmp.eq.clone(), terms.sign_same.clone(), 1);
+        (gt, eq)
+    } else {
+        (cmp.gt.clone(), cmp.eq.clone())
+    };
+    let ge_bit = builder.emit_binop(NodeOp::Or, gt_bit, eq_bit, 1);
+    builder.assign_with_name(ctx.cell_name(), ge_bit, operands.y_bit.clone());
+    Ok(builder.finish())
+}
+
+struct ComparatorOperands {
+    a_bits: Vec<BitRef>,
+    b_bits: Vec<BitRef>,
+    y_bit: BitRef,
+    width: usize,
+    a_signed: bool,
+    b_signed: bool,
+}
+
+impl ComparatorOperands {
+    fn new(cell: &Cell, ctx: &mut Ctx) -> Result<Self> {
+        let a = ctx.bitref(cell, "A")?;
+        let b = ctx.bitref(cell, "B")?;
+        let y = ctx.bitref(cell, "Y")?;
+
+        let a_width = expect_param_u32(cell, ctx, "A_WIDTH")?;
+        let b_width = expect_param_u32(cell, ctx, "B_WIDTH")?;
+        let y_width = expect_param_u32(cell, ctx, "Y_WIDTH")?;
+
+        ctx.expect_width("A", &a, a_width)?;
+        ctx.expect_width("B", &b, b_width)?;
+        ctx.expect_width("Y", &y, y_width)?;
+
+        if y_width != 1 {
+            bail!(
+                "cell `{}` in module `{}` must have Y_WIDTH=1 but found {y_width}",
+                ctx.cell_name(),
+                ctx.module_name()
+            );
+        }
+
+        let a_signed = expect_param_bool(cell, ctx, "A_SIGNED")?;
+        let b_signed = expect_param_bool(cell, ctx, "B_SIGNED")?;
+
+        let mut a_bits = bitref_to_bits(&a)?;
+        ensure!(
+            a_bits.len() == a_width as usize,
+            "pin `A` on cell `{}` in module `{}` has width {} but expected {}",
+            ctx.cell_name(),
+            ctx.module_name(),
+            a_bits.len(),
+            a_width
+        );
+
+        let mut b_bits = bitref_to_bits(&b)?;
+        ensure!(
+            b_bits.len() == b_width as usize,
+            "pin `B` on cell `{}` in module `{}` has width {} but expected {}",
+            ctx.cell_name(),
+            ctx.module_name(),
+            b_bits.len(),
+            b_width
+        );
+
+        let y_bits = bitref_to_bits(&y)?;
+        ensure!(
+            y_bits.len() == 1,
+            "pin `Y` on cell `{}` in module `{}` must have a single bit output",
+            ctx.cell_name(),
+            ctx.module_name()
+        );
+
+        let width = std::cmp::max(a_bits.len(), b_bits.len());
+        a_bits = extend_bits(a_bits, width, a_signed);
+        b_bits = extend_bits(b_bits, width, b_signed);
+
+        Ok(Self {
+            a_bits,
+            b_bits,
+            y_bit: y_bits[0].clone(),
+            width,
+            a_signed,
+            b_signed,
+        })
+    }
+
+    fn is_signed_relational(&self) -> bool {
+        self.a_signed || self.b_signed
+    }
+}
+
+struct SignedTerms {
+    a_sign: BitRef,
+    b_sign: BitRef,
+    sign_same: BitRef,
+    not_a_sign: BitRef,
+    not_b_sign: BitRef,
+}
+
+fn build_signed_terms(
+    builder: &mut CellLoweringBuilder,
+    a_bits: &[BitRef],
+    b_bits: &[BitRef],
+    a_signed: bool,
+    b_signed: bool,
+) -> SignedTerms {
+    let a_sign = if a_signed {
+        a_bits.last().cloned().unwrap_or_else(zero_bit)
+    } else {
+        builder
+            .materialize_bits(&[zero_bit()])
+            .into_iter()
+            .next()
+            .unwrap()
+    };
+    let b_sign = if b_signed {
+        b_bits.last().cloned().unwrap_or_else(zero_bit)
+    } else {
+        builder
+            .materialize_bits(&[zero_bit()])
+            .into_iter()
+            .next()
+            .unwrap()
+    };
+    let sign_diff = builder.emit_binop(NodeOp::Xor, a_sign.clone(), b_sign.clone(), 1);
+    let sign_same = invert_bit(builder, &sign_diff);
+    let not_a_sign = invert_bit(builder, &a_sign);
+    let not_b_sign = invert_bit(builder, &b_sign);
+    SignedTerms {
+        a_sign,
+        b_sign,
+        sign_same,
+        not_a_sign,
+        not_b_sign,
+    }
+}
+
+fn signed_lt(
+    builder: &mut CellLoweringBuilder,
+    cmp: &CompareSignals,
+    terms: &SignedTerms,
+) -> BitRef {
+    let diff_term = builder.emit_binop(
+        NodeOp::And,
+        terms.a_sign.clone(),
+        terms.not_b_sign.clone(),
+        1,
+    );
+    let mag_term = builder.emit_binop(NodeOp::And, terms.sign_same.clone(), cmp.lt.clone(), 1);
+    builder.emit_binop(NodeOp::Or, diff_term, mag_term, 1)
+}
+
+fn invert_bit(builder: &mut CellLoweringBuilder, bit: &BitRef) -> BitRef {
+    match bit {
+        BitRef::Const(constant) => match constant.value.as_str() {
+            "0b0" => one_bit(),
+            "0b1" => zero_bit(),
+            _ => builder.emit_unop(NodeOp::Not, bit.clone(), 1),
+        },
+        _ => builder.emit_unop(NodeOp::Not, bit.clone(), 1),
+    }
+}
+
+fn signed_gt(
+    builder: &mut CellLoweringBuilder,
+    cmp: &CompareSignals,
+    terms: &SignedTerms,
+) -> BitRef {
+    let diff_term = builder.emit_binop(
+        NodeOp::And,
+        terms.not_a_sign.clone(),
+        terms.b_sign.clone(),
+        1,
+    );
+    let mag_term = builder.emit_binop(NodeOp::And, terms.sign_same.clone(), cmp.gt.clone(), 1);
+    builder.emit_binop(NodeOp::Or, diff_term, mag_term, 1)
+}
+
+struct CellLoweringBuilder<'a> {
+    cell_name: &'a str,
+    tmp_net_index: usize,
+    tmp_node_index: usize,
+    lowered: LoweredCell,
+}
+
+impl<'a> CellLoweringBuilder<'a> {
+    fn new(cell_name: &'a str) -> Self {
+        Self {
+            cell_name,
+            tmp_net_index: 0,
+            tmp_node_index: 0,
+            lowered: LoweredCell::default(),
+        }
+    }
+
+    fn finish(self) -> LoweredCell {
+        self.lowered
+    }
+
+    fn alloc_tmp_bitref(&mut self, width: u32) -> BitRef {
+        assert!(width > 0, "temporary nets must have positive width");
+        let name = format!("{}__v2m_cmp_net{}", self.cell_name, self.tmp_net_index);
+        self.tmp_net_index += 1;
+        self.lowered.push_net(
+            name.clone(),
+            NirNet {
+                bits: width,
+                attrs: None,
+            },
+        );
+        BitRef::Net(BitRefNet {
+            net: name,
+            lsb: 0,
+            msb: width - 1,
+        })
+    }
+
+    fn emit_node(&mut self, name: Option<String>, node: NirNode) -> String {
+        let node_name = match name {
+            Some(name) => name,
+            None => {
+                let generated = format!("{}__v2m_cmp_node{}", self.cell_name, self.tmp_node_index);
+                self.tmp_node_index += 1;
+                generated
+            }
+        };
+        self.lowered.push_node(node_name.clone(), node);
+        node_name
+    }
+
+    fn emit_binop(&mut self, op: NodeOp, left: BitRef, right: BitRef, width: u32) -> BitRef {
+        let out = self.alloc_tmp_bitref(width);
+        self.emit_named_binop(None, op, left, right, out.clone());
+        out
+    }
+
+    fn emit_named_binop(
+        &mut self,
+        name: Option<&str>,
+        op: NodeOp,
+        left: BitRef,
+        right: BitRef,
+        out: BitRef,
+    ) {
+        let mut pins = BTreeMap::new();
+        pins.insert("A".to_string(), left);
+        pins.insert("B".to_string(), right);
+        pins.insert("Y".to_string(), out.clone());
+        let node = NirNode::new(op, Ctx::bitref_width(&out), pins);
+        self.emit_node(name.map(|n| n.to_string()), node);
+    }
+
+    fn emit_unop(&mut self, op: NodeOp, input: BitRef, width: u32) -> BitRef {
+        let out = self.alloc_tmp_bitref(width);
+        self.emit_named_unop(None, op, input, out.clone());
+        out
+    }
+
+    fn emit_named_unop(
+        &mut self,
+        name: Option<&str>,
+        op: NodeOp,
+        input: BitRef,
+        out: BitRef,
+    ) -> BitRef {
+        let mut pins = BTreeMap::new();
+        pins.insert("A".to_string(), input);
+        pins.insert("Y".to_string(), out.clone());
+        let node = NirNode::new(op, Ctx::bitref_width(&out), pins);
+        self.emit_node(name.map(|n| n.to_string()), node);
+        out
+    }
+
+    fn emit_slice(&mut self, name: Option<&str>, input: BitRef, out: BitRef) {
+        let mut pins = BTreeMap::new();
+        pins.insert("A".to_string(), input);
+        pins.insert("Y".to_string(), out.clone());
+        let node = NirNode::new(NodeOp::Slice, Ctx::bitref_width(&out), pins);
+        self.emit_node(name.map(|n| n.to_string()), node);
+    }
+
+    fn materialize_bits(&mut self, bits: &[BitRef]) -> Vec<BitRef> {
+        let mut result = Vec::with_capacity(bits.len());
+        for bit in bits {
+            let target = self.alloc_tmp_bitref(1);
+            self.emit_slice(None, bit.clone(), target.clone());
+            result.push(target);
+        }
+        result
+    }
+
+    fn reduce_bits(&mut self, bits: &[BitRef], op: NodeOp) -> Result<BitRef> {
+        match bits.len() {
+            0 => match op {
+                NodeOp::And => Ok(one_bit()),
+                NodeOp::Or => Ok(zero_bit()),
+                _ => bail!("unsupported reduction op"),
+            },
+            1 => Ok(bits[0].clone()),
+            _ => {
+                let mid = bits.len() / 2;
+                let left = self.reduce_bits(&bits[..mid], op.clone())?;
+                let right = self.reduce_bits(&bits[mid..], op.clone())?;
+                Ok(self.emit_binop(op, left, right, 1))
+            }
+        }
+    }
+
+    fn assign_with_name(&mut self, name: &str, source: BitRef, target: BitRef) {
+        self.emit_slice(Some(name), source, target);
+    }
+}
+
+fn build_unsigned_compare(
+    builder: &mut CellLoweringBuilder,
+    a_bits: &[BitRef],
+    b_bits: &[BitRef],
+) -> Result<CompareSignals> {
+    ensure!(
+        a_bits.len() == b_bits.len(),
+        "operand width mismatch in comparator lowering"
+    );
+    match a_bits.len() {
+        0 => Ok(CompareSignals {
+            eq: one_bit(),
+            lt: zero_bit(),
+            gt: zero_bit(),
+        }),
+        1 => {
+            let a_bit = a_bits[0].clone();
+            let b_bit = b_bits[0].clone();
+            let eq = builder.emit_binop(NodeOp::Xnor, a_bit.clone(), b_bit.clone(), 1);
+            let not_a = builder.emit_unop(NodeOp::Not, a_bit.clone(), 1);
+            let not_b = builder.emit_unop(NodeOp::Not, b_bit.clone(), 1);
+            let lt = builder.emit_binop(NodeOp::And, not_a, b_bit, 1);
+            let gt = builder.emit_binop(NodeOp::And, a_bit, not_b, 1);
+            Ok(CompareSignals { eq, lt, gt })
+        }
+        _ => {
+            let mid = a_bits.len() / 2;
+            let low = build_unsigned_compare(builder, &a_bits[..mid], &b_bits[..mid])?;
+            let high = build_unsigned_compare(builder, &a_bits[mid..], &b_bits[mid..])?;
+
+            let CompareSignals {
+                eq: eq_low,
+                lt: lt_low,
+                gt: gt_low,
+            } = low;
+            let CompareSignals {
+                eq: eq_high,
+                lt: lt_high,
+                gt: gt_high,
+            } = high;
+
+            let eq = builder.emit_binop(NodeOp::And, eq_high.clone(), eq_low.clone(), 1);
+            let lt_high_term = builder.emit_binop(NodeOp::And, eq_high.clone(), lt_low.clone(), 1);
+            let lt = builder.emit_binop(NodeOp::Or, lt_high.clone(), lt_high_term, 1);
+            let gt_high_term = builder.emit_binop(NodeOp::And, eq_high.clone(), gt_low.clone(), 1);
+            let gt = builder.emit_binop(NodeOp::Or, gt_high.clone(), gt_high_term, 1);
+            Ok(CompareSignals { eq, lt, gt })
+        }
+    }
+}
+
+fn build_equality_bit(
+    builder: &mut CellLoweringBuilder,
+    a_bits: &[BitRef],
+    b_bits: &[BitRef],
+) -> Result<BitRef> {
+    ensure!(
+        a_bits.len() == b_bits.len(),
+        "operand width mismatch in equality lowering",
+    );
+    if a_bits.is_empty() {
+        return Ok(one_bit());
+    }
+
+    let mut xnor_bits = Vec::with_capacity(a_bits.len());
+    for (a_bit, b_bit) in a_bits.iter().zip(b_bits.iter()) {
+        xnor_bits.push(builder.emit_binop(NodeOp::Xnor, a_bit.clone(), b_bit.clone(), 1));
+    }
+    builder.reduce_bits(&xnor_bits, NodeOp::And)
+}
+
+fn bitref_to_bits(bitref: &BitRef) -> Result<Vec<BitRef>> {
+    match bitref {
+        BitRef::Net(BitRefNet { net, lsb, msb }) => {
+            let mut bits = Vec::with_capacity((*msb - *lsb + 1) as usize);
+            for bit in *lsb..=*msb {
+                bits.push(BitRef::Net(BitRefNet {
+                    net: net.clone(),
+                    lsb: bit,
+                    msb: bit,
+                }));
+            }
+            Ok(bits)
+        }
+        BitRef::Const(constant) => const_to_bits(constant),
+        BitRef::Concat(BitRefConcat { concat }) => {
+            let mut result = Vec::new();
+            for part in concat.iter().rev() {
+                result.extend(bitref_to_bits(part)?);
+            }
+            Ok(result)
+        }
+    }
+}
+
+fn const_to_bits(constant: &BitRefConst) -> Result<Vec<BitRef>> {
+    let text = constant
+        .value
+        .strip_prefix("0b")
+        .ok_or_else(|| anyhow!("constant value `{}` must be binary", constant.value))?;
+    let mut bits = Vec::with_capacity(constant.width as usize);
+    for ch in text.chars().rev() {
+        match ch {
+            '0' => bits.push(zero_bit()),
+            '1' => bits.push(one_bit()),
+            other => bail!("unsupported constant bit `{other}` in comparator lowering"),
+        }
+    }
+    ensure!(
+        bits.len() == constant.width as usize,
+        "constant bit count does not match declared width"
+    );
+    Ok(bits)
+}
+
+fn extend_bits(mut bits: Vec<BitRef>, target: usize, signed: bool) -> Vec<BitRef> {
+    let current = bits.len();
+    if current >= target {
+        bits
+    } else {
+        let fill_count = target - current;
+        if signed && current > 0 {
+            let sign_bit = bits[current - 1].clone();
+            bits.extend(std::iter::repeat_with(|| sign_bit.clone()).take(fill_count));
+        } else {
+            bits.extend(std::iter::repeat_with(zero_bit).take(fill_count));
+        }
+        bits
+    }
+}
+
+fn zero_bit() -> BitRef {
+    BitRef::Const(BitRefConst {
+        value: "0b0".to_string(),
+        width: 1,
+    })
+}
+
+fn one_bit() -> BitRef {
+    BitRef::Const(BitRefConst {
+        value: "0b1".to_string(),
+        width: 1,
+    })
+}

--- a/v2m/frontends/yosys_bridge/src/cells/mod.rs
+++ b/v2m/frontends/yosys_bridge/src/cells/mod.rs
@@ -1,11 +1,38 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
 
+use v2m_formats::nir::Net as NirNet;
+
 use crate::context::Ctx;
+use crate::nir_node::NirNode;
 use yosys_bridge::loader::Cell;
 
 pub mod arith;
+pub mod compare;
 pub mod logic;
+
+#[derive(Debug, Default)]
+pub struct LoweredCell {
+    pub nodes: Vec<(String, NirNode)>,
+    pub extra_nets: Vec<(String, NirNet)>,
+}
+
+impl LoweredCell {
+    pub fn single(name: &str, node: NirNode) -> Self {
+        Self {
+            nodes: vec![(name.to_string(), node)],
+            extra_nets: Vec::new(),
+        }
+    }
+
+    pub fn push_node(&mut self, name: String, node: NirNode) {
+        self.nodes.push((name, node));
+    }
+
+    pub fn push_net(&mut self, name: String, net: NirNet) {
+        self.extra_nets.push((name, net));
+    }
+}
 
 fn expect_param_value<'a>(cell: &'a Cell, ctx: &Ctx, name: &str) -> Result<&'a Value> {
     cell.parameters.get(name).ok_or_else(|| {

--- a/v2m/frontends/yosys_bridge/tests/comparators.rs
+++ b/v2m/frontends/yosys_bridge/tests/comparators.rs
@@ -1,0 +1,300 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use frontends_yosys_bridge::rtlil_to_nir;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use serde_json::{json, Value};
+use v2m_evaluator::{Evaluator, Packed, PackedIndex, SimOptions};
+use v2m_formats::nir::PortDirection;
+use yosys_bridge::loader::{Cell, Module, RtlilJson};
+
+const RANDOM_ITERS: usize = 100;
+
+#[test]
+fn comparator_random_vectors() -> Result<()> {
+    let cases = [
+        ("$eq", false, false),
+        ("$ne", false, false),
+        ("$lt", false, false),
+        ("$lt", true, false),
+        ("$le", false, false),
+        ("$le", true, true),
+        ("$gt", false, false),
+        ("$gt", true, true),
+        ("$ge", false, false),
+        ("$ge", true, false),
+    ];
+    let widths = [(8, 8), (13, 17), (32, 24)];
+
+    for &(kind, a_signed, b_signed) in &cases {
+        for &(a_width, b_width) in &widths {
+            run_compare_case(kind, a_width, b_width, a_signed, b_signed)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn run_compare_case(
+    kind: &str,
+    a_width: u32,
+    b_width: u32,
+    a_signed: bool,
+    b_signed: bool,
+) -> Result<()> {
+    let design = make_comparator_design(kind, a_width, b_width, a_signed, b_signed);
+    let nir = rtlil_to_nir(&design)?;
+    let module = nir
+        .modules
+        .get(design.top.as_str())
+        .expect("module present");
+
+    let mut evaluator = Evaluator::new(&nir, 1, SimOptions::default())?;
+    let (mut inputs, input_indices) = build_input_layout(module);
+    let output_indices = build_output_layout(module);
+
+    let mut rng = StdRng::seed_from_u64(0x4d5a2d19fe77beef);
+    for _ in 0..RANDOM_ITERS {
+        let a_value = rng.gen::<u64>() & mask_value(a_width);
+        let b_value = rng.gen::<u64>() & mask_value(b_width);
+
+        set_input_value(&mut inputs, input_indices["a"], a_width, a_value);
+        set_input_value(&mut inputs, input_indices["b"], b_width, b_value);
+
+        evaluator.set_inputs(&inputs)?;
+        evaluator.comb_eval()?;
+
+        let outputs = evaluator.get_outputs();
+        let y_index = output_indices["y"];
+        let observed = (outputs.lane(y_index, 0)[0] & 1) != 0;
+        let expected =
+            expected_result(kind, a_value, b_value, a_width, b_width, a_signed, b_signed);
+        assert_eq!(
+            observed, expected,
+            "mismatch for {kind} with a_width={a_width} b_width={b_width} \
+             a_signed={a_signed} b_signed={b_signed} a=0x{a_value:x} b=0x{b_value:x}"
+        );
+    }
+
+    Ok(())
+}
+
+fn build_input_layout(
+    module: &v2m_formats::nir::Module,
+) -> (Packed, BTreeMap<String, PackedIndex>) {
+    let mut inputs = Packed::new(1);
+    let mut indices = BTreeMap::new();
+    for (name, port) in &module.ports {
+        if matches!(port.dir, PortDirection::Input | PortDirection::Inout) {
+            let index = inputs.allocate(port.bits as usize);
+            indices.insert(name.clone(), index);
+        }
+    }
+    (inputs, indices)
+}
+
+fn build_output_layout(module: &v2m_formats::nir::Module) -> BTreeMap<String, PackedIndex> {
+    let mut outputs = Packed::new(1);
+    let mut indices = BTreeMap::new();
+    for (name, port) in &module.ports {
+        if matches!(port.dir, PortDirection::Output | PortDirection::Inout) {
+            let index = outputs.allocate(port.bits as usize);
+            indices.insert(name.clone(), index);
+        }
+    }
+    indices
+}
+
+fn set_input_value(buffer: &mut Packed, index: PackedIndex, width: u32, value: u64) {
+    for bit in 0..width as usize {
+        let lane = buffer.lane_mut(index, bit);
+        lane[0] = if (value >> bit) & 1 == 1 { u64::MAX } else { 0 };
+    }
+}
+
+fn mask_value(width: u32) -> u64 {
+    if width == 0 {
+        0
+    } else if width >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    }
+}
+
+fn expected_result(
+    kind: &str,
+    a_raw: u64,
+    b_raw: u64,
+    a_width: u32,
+    b_width: u32,
+    a_signed: bool,
+    b_signed: bool,
+) -> bool {
+    let a_signed_value = if a_signed {
+        sign_extend_to_i128(a_raw, a_width)
+    } else {
+        zero_extend_to_u128(a_raw, a_width) as i128
+    };
+    let b_signed_value = if b_signed {
+        sign_extend_to_i128(b_raw, b_width)
+    } else {
+        zero_extend_to_u128(b_raw, b_width) as i128
+    };
+    let a_unsigned_value = zero_extend_to_u128(a_raw, a_width);
+    let b_unsigned_value = zero_extend_to_u128(b_raw, b_width);
+
+    match kind {
+        "$eq" => a_unsigned_value == b_unsigned_value && a_signed_value == b_signed_value,
+        "$ne" => a_unsigned_value != b_unsigned_value || a_signed_value != b_signed_value,
+        "$lt" => {
+            if a_signed || b_signed {
+                a_signed_value < b_signed_value
+            } else {
+                a_unsigned_value < b_unsigned_value
+            }
+        }
+        "$le" => {
+            if a_signed || b_signed {
+                a_signed_value <= b_signed_value
+            } else {
+                a_unsigned_value <= b_unsigned_value
+            }
+        }
+        "$gt" => {
+            if a_signed || b_signed {
+                a_signed_value > b_signed_value
+            } else {
+                a_unsigned_value > b_unsigned_value
+            }
+        }
+        "$ge" => {
+            if a_signed || b_signed {
+                a_signed_value >= b_signed_value
+            } else {
+                a_unsigned_value >= b_unsigned_value
+            }
+        }
+        other => panic!("unsupported comparator `{other}`"),
+    }
+}
+
+fn zero_extend_to_u128(value: u64, width: u32) -> u128 {
+    if width == 0 {
+        0
+    } else if width >= 128 {
+        value as u128
+    } else {
+        let mask = (1u128 << width) - 1;
+        (value as u128) & mask
+    }
+}
+
+fn sign_extend_to_i128(value: u64, width: u32) -> i128 {
+    if width == 0 {
+        0
+    } else if width >= 128 {
+        value as i128
+    } else {
+        let masked = zero_extend_to_u128(value, width);
+        let shift = 128 - width;
+        ((masked << shift) as i128) >> shift
+    }
+}
+
+fn make_comparator_design(
+    kind: &str,
+    a_width: u32,
+    b_width: u32,
+    a_signed: bool,
+    b_signed: bool,
+) -> RtlilJson {
+    let mut next_bit: i64 = 1;
+    let a_bits = bit_ids(&mut next_bit, a_width);
+    let b_bits = bit_ids(&mut next_bit, b_width);
+    let y_bits = bit_ids(&mut next_bit, 1);
+
+    let mut ports = BTreeMap::new();
+    ports.insert("a".to_string(), port(&a_bits, "input"));
+    ports.insert("b".to_string(), port(&b_bits, "input"));
+    ports.insert("y".to_string(), port(&y_bits, "output"));
+
+    let mut netnames = BTreeMap::new();
+    netnames.insert("a".to_string(), net(&a_bits));
+    netnames.insert("b".to_string(), net(&b_bits));
+    netnames.insert("y".to_string(), net(&y_bits));
+
+    let mut cells = BTreeMap::new();
+    cells.insert(
+        "cmp".to_string(),
+        comparator_cell(
+            kind, &a_bits, &b_bits, &y_bits, a_width, b_width, a_signed, b_signed,
+        ),
+    );
+
+    let mut attributes = BTreeMap::new();
+    attributes.insert("top".to_string(), json!(1));
+
+    let module = Module {
+        attributes,
+        ports,
+        cells,
+        netnames,
+    };
+
+    RtlilJson {
+        top: "cmp".to_string(),
+        modules: BTreeMap::from([(module_name("cmp"), module)]),
+    }
+}
+
+fn bit_ids(next: &mut i64, width: u32) -> Vec<i64> {
+    let mut bits = Vec::with_capacity(width as usize);
+    for _ in 0..width {
+        bits.push(*next);
+        *next += 1;
+    }
+    bits
+}
+
+fn module_name(name: &str) -> String {
+    name.to_string()
+}
+
+fn port(bits: &[i64], direction: &str) -> Value {
+    json!({ "direction": direction, "bits": bits })
+}
+
+fn net(bits: &[i64]) -> Value {
+    json!({ "bits": bits })
+}
+
+fn comparator_cell(
+    kind: &str,
+    a_bits: &[i64],
+    b_bits: &[i64],
+    y_bits: &[i64],
+    a_width: u32,
+    b_width: u32,
+    a_signed: bool,
+    b_signed: bool,
+) -> Cell {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("A_WIDTH".to_string(), json!(a_width));
+    parameters.insert("B_WIDTH".to_string(), json!(b_width));
+    parameters.insert("Y_WIDTH".to_string(), json!(1u32));
+    parameters.insert("A_SIGNED".to_string(), json!(a_signed));
+    parameters.insert("B_SIGNED".to_string(), json!(b_signed));
+
+    let mut connections = BTreeMap::new();
+    connections.insert("A".to_string(), json!(a_bits));
+    connections.insert("B".to_string(), json!(b_bits));
+    connections.insert("Y".to_string(), json!(y_bits));
+
+    Cell {
+        kind: kind.to_string(),
+        parameters,
+        attributes: BTreeMap::new(),
+        connections,
+    }
+}


### PR DESCRIPTION
## Summary
- expand $eq/$ne/$lt/$le/$gt/$ge cells into NIR logic using a temporary-net builder
- allow module lowering to attach generated nets and multiple nodes per cell
- add randomized comparator regression and loader guard for remaining comparator cells

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cc8ceed3b48323a7fc7d9b3673a910